### PR TITLE
Ajoute la gestion d'erreur et du chargement pour l'estimation API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,257 @@
+import React, { useState, useEffect } from 'react';
+import { BarChart3, Calculator, Users, Package, MapPin, UserCheck } from 'lucide-react';
+import { Header } from './components/Layout/Header';
+import { Dashboard } from './components/Dashboard/Dashboard';
+import { Simulator } from './components/Simulator/Simulator';
+import { SalariesManager } from './components/Salaries/SalariesManager';
+import { MateriauxManager } from './components/Materiaux/MateriauxManager';
+import { ChantiersManager } from './components/Chantiers/ChantiersManager';
+import { SousTraitantsManager } from './components/SousTraitants/SousTraitantsManager';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from './components/UI/Tabs';
+import { ToastProvider } from './components/UI/Toast';
+import { useLocalStorage } from './hooks/useLocalStorage';
+import { SalarieSchema, MateriauSchema, ChantierSchema, SousTraitantSchema, Salarie, Materiau, Chantier, SousTraitant } from './schemas';
+import { z } from 'zod';
+import { newId } from './lib/id';
+import { estimerChantier, type EstimationResponse, type PosteTravail } from '@/domain/api';
+
+function App() {
+  const [activeTab, setActiveTab] = useState(() => {
+    // Récupérer l'onglet depuis l'URL hash
+    const hash = window.location.hash.slice(1);
+    return ['dashboard', 'simulator', 'salaries', 'materiaux', 'sous-traitants', 'chantiers'].includes(hash) 
+      ? hash 
+      : 'dashboard';
+  });
+
+  // Hooks de persistance avec validation Zod
+  const salariesStorage = useLocalStorage({
+    key: 'btp-salaries',
+    schema: z.array(SalarieSchema),
+    defaultValue: [] as Salarie[],
+    version: 1
+  });
+
+  const materiauxStorage = useLocalStorage({
+    key: 'btp-materiaux',
+    schema: z.array(MateriauSchema),
+    defaultValue: [] as Materiau[],
+    version: 1
+  });
+
+  const sousTraitantsStorage = useLocalStorage({
+    key: 'btp-sous-traitants',
+    schema: z.array(SousTraitantSchema),
+    defaultValue: [] as SousTraitant[],
+    version: 1
+  });
+
+  const chantiersStorage = useLocalStorage({
+    key: 'btp-chantiers',
+    schema: z.array(ChantierSchema),
+    defaultValue: [] as Chantier[],
+    version: 1
+  });
+
+  const [postes, setPostes] = useState<PosteTravail[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [estimation, setEstimation] = useState<EstimationResponse | null>(null);
+  const [isEstimating, setIsEstimating] = useState(false);
+
+  // Synchroniser l'URL avec l'onglet actif
+  useEffect(() => {
+    window.location.hash = activeTab;
+  }, [activeTab]);
+
+  // Écouter les changements d'URL
+  useEffect(() => {
+    const handleHashChange = () => {
+      const hash = window.location.hash.slice(1);
+      if (['dashboard', 'simulator', 'salaries', 'materiaux', 'sous-traitants', 'chantiers'].includes(hash)) {
+        setActiveTab(hash);
+      }
+    };
+
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  const tabs = [
+    { 
+      id: 'dashboard', 
+      label: 'Tableau de bord', 
+      icon: <BarChart3 className="h-4 w-4" /> 
+    },
+    { 
+      id: 'simulator', 
+      label: 'Simulateur', 
+      icon: <Calculator className="h-4 w-4" /> 
+    },
+    { 
+      id: 'salaries', 
+      label: 'Salariés', 
+      icon: <Users className="h-4 w-4" /> 
+    },
+    { 
+      id: 'materiaux', 
+      label: 'Matériaux', 
+      icon: <Package className="h-4 w-4" /> 
+    },
+    { 
+      id: 'sous-traitants', 
+      label: 'Sous-traitants', 
+      icon: <UserCheck className="h-4 w-4" /> 
+    },
+    { 
+      id: 'chantiers', 
+      label: 'Chantiers', 
+      icon: <MapPin className="h-4 w-4" /> 
+    }
+  ];
+
+  return (
+    <ToastProvider>
+      <div className="min-h-screen bg-gray-100">
+        <Header />
+        
+        <div className="max-w-7xl mx-auto px-4 pt-6">
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="mb-6">
+              {tabs.map((tab) => (
+                <TabsTrigger
+                  key={tab.id}
+                  value={tab.id}
+                  icon={tab.icon}
+                >
+                  {tab.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+
+            <main className="pb-8">
+              <TabsContent value="dashboard">
+                <Dashboard 
+                  chantiers={chantiersStorage.data}
+                  salaries={salariesStorage.data}
+                  materiaux={materiauxStorage.data}
+                />
+              </TabsContent>
+
+              <TabsContent value="simulator">
+                {error && (
+                  <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+                    {error}
+                  </div>
+                )}
+                <div className="mb-4 flex flex-wrap gap-2">
+                  <button
+                    onClick={() => {
+                      setPostes([
+                        { id: newId(), nom: 'Démolition', charge: 10 },
+                        { id: newId(), nom: 'Plomberie', charge: 18 },
+                        { id: newId(), nom: 'Électricité', charge: 8 },
+                        { id: newId(), nom: 'Carrelage', charge: 22 },
+                        { id: newId(), nom: 'Peinture', charge: 12 }
+                      ]);
+                      setError(null);
+                      setEstimation(null);
+                    }}
+                    className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
+                  >
+                    Exemple SDB
+                  </button>
+                  <button
+                    onClick={async () => {
+                      if (isEstimating) {
+                        return;
+                      }
+                      if (postes.length === 0) {
+                        setError('Veuillez ajouter au moins un poste avant de lancer une estimation.');
+                        return;
+                      }
+                      setIsEstimating(true);
+                      setError(null);
+                      try {
+                        const result = await estimerChantier({ postes });
+                        setEstimation(result);
+                      } catch (apiError) {
+                        setEstimation(null);
+                        setError(apiError instanceof Error ? apiError.message : 'Une erreur est survenue lors de l\'estimation.');
+                      } finally {
+                        setIsEstimating(false);
+                      }
+                    }}
+                    disabled={isEstimating}
+                    className={`px-4 py-2 rounded-md text-white transition-colors ${
+                      isEstimating
+                        ? 'cursor-not-allowed bg-gray-400'
+                        : 'bg-emerald-600 hover:bg-emerald-700'
+                    }`}
+                  >
+                    {isEstimating ? 'Estimation…' : 'Estimer via API'}
+                  </button>
+                </div>
+                {estimation && (
+                  <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm text-emerald-700">
+                    <p>
+                      Estimation totale HT :
+                      {' '}
+                      {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(estimation.totalHT)}
+                    </p>
+                    <p>Marge estimée : {estimation.margeEstimee}%</p>
+                  </div>
+                )}
+                <Simulator
+                  salaries={salariesStorage.data}
+                  materiaux={materiauxStorage.data}
+                  chantiers={chantiersStorage.data}
+                />
+              </TabsContent>
+
+              <TabsContent value="salaries">
+                <SalariesManager 
+                  salaries={salariesStorage.data}
+                  setSalaries={salariesStorage.setData}
+                  isLoading={salariesStorage.isLoading}
+                  error={salariesStorage.error}
+                />
+              </TabsContent>
+
+              <TabsContent value="materiaux">
+                <MateriauxManager 
+                  materiaux={materiauxStorage.data}
+                  setMateriaux={materiauxStorage.setData}
+                  isLoading={materiauxStorage.isLoading}
+                  error={materiauxStorage.error}
+                />
+              </TabsContent>
+
+              <TabsContent value="sous-traitants">
+                <SousTraitantsManager 
+                  sousTraitants={sousTraitantsStorage.data}
+                  setSousTraitants={sousTraitantsStorage.setData}
+                  isLoading={sousTraitantsStorage.isLoading}
+                  error={sousTraitantsStorage.error}
+                />
+              </TabsContent>
+
+              <TabsContent value="chantiers">
+                <ChantiersManager 
+                  chantiers={chantiersStorage.data}
+                  setChantiers={chantiersStorage.setData}
+                  salaries={salariesStorage.data}
+                  materiaux={materiauxStorage.data}
+                  sousTraitants={sousTraitantsStorage.data}
+                  isLoading={chantiersStorage.isLoading}
+                  error={chantiersStorage.error}
+                />
+              </TabsContent>
+            </main>
+          </Tabs>
+        </div>
+      </div>
+    </ToastProvider>
+  );
+}
+
+export default App;

--- a/src/components/Chantiers/ChantierForm.tsx
+++ b/src/components/Chantiers/ChantierForm.tsx
@@ -1,0 +1,1081 @@
+import React, { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Save, X, Plus, Clock, Trash2, Calculator } from 'lucide-react';
+import { Chantier, Salarie, Materiau, ChantierFormData, ChantierFormSchema } from '../../schemas';
+import { calculerCoutsChantier } from '../../services/costEngine';
+import { formatEuro } from '../../utils/calculsFiscaux';
+import { calculerCoutChantierSalarie } from '../../utils/calculsFiscaux';
+import { useToast } from '../UI/Toast';
+
+interface ChantierFormProps {
+  chantier?: Chantier | null;
+  salaries: Salarie[];
+  materiaux: Materiau[];
+  sousTraitants: SousTraitant[];
+  onSave: (chantier: Chantier) => void;
+  onCancel: () => void;
+}
+
+export const ChantierForm: React.FC<ChantierFormProps> = ({
+  chantier,
+  salaries,
+  materiaux,
+  sousTraitants,
+  onSave,
+  onCancel
+}) => {
+  const { addToast } = useToast();
+  const isEditing = !!chantier;
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors }
+  } = useForm<ChantierFormData>({
+    resolver: zodResolver(ChantierFormSchema),
+    defaultValues: chantier ? {
+      reference: chantier.reference,
+      nom: chantier.nom,
+      client: chantier.client,
+      adresse: chantier.adresse,
+      dateDebut: chantier.dateDebut,
+      dateFin: chantier.dateFin,
+      fraisGeneraux: chantier.fraisGeneraux,
+      margeObjectif: chantier.margeObjectif,
+      prixVenteHT: chantier.prixVenteHT,
+      prixVenteTTC: chantier.prixVenteTTC,
+      status: chantier.status,
+      tags: chantier.tags,
+      notes: chantier.notes
+    } : {
+      reference: `CH${Date.now()}`,
+      fraisGeneraux: 15,
+      margeObjectif: 20,
+      status: 'prospect',
+      tags: [],
+      client: {
+        nom: '',
+        adresse: ''
+      }
+    }
+  });
+
+  // États locaux pour la gestion des salariés et matériaux
+  const [chantierSalaries, setChantierSalaries] = useState(chantier?.salaries || []);
+  const [chantierMateriaux, setChantierMateriaux] = useState(chantier?.materiaux || []);
+  const [chantierSousTraitants, setChantierSousTraitants] = useState(chantier?.sousTraitants || []);
+  const [showSalarieForm, setShowSalarieForm] = useState(false);
+  const [showMateriauForm, setShowMateriauForm] = useState(false);
+  const [showSousTraitantForm, setShowSousTraitantForm] = useState(false);
+  const [showPresenceForm, setShowPresenceForm] = useState<string | null>(null);
+
+  // États pour les formulaires d'ajout
+  const [selectedSalarieId, setSelectedSalarieId] = useState('');
+  const [selectedSousTraitantId, setSelectedSousTraitantId] = useState('');
+  const [newMateriau, setNewMateriau] = useState({
+    materiauId: '',
+    quantite: '',
+    prixUnitaireReel: '',
+    tauxTVA: '20' as const
+  });
+  const [newSousTraitant, setNewSousTraitant] = useState({
+    sousTraitantId: '',
+    description: '',
+    dateDebut: '',
+    dateFin: '',
+    montantForfait: '',
+    notes: ''
+  });
+  const [newPresence, setNewPresence] = useState({
+    date: '',
+    heuresPresence: '8',
+    heuresSupplementaires: '0',
+    tacheDescription: '',
+    commentaire: ''
+  });
+
+  // Calculs en temps réel
+  const couts = React.useMemo(() => {
+    const chantierTemp: Chantier = {
+      id: chantier?.id || 'temp',
+      reference: watch('reference') || '',
+      nom: watch('nom') || '',
+      client: watch('client') || { nom: '', adresse: '' },
+      adresse: watch('adresse') || '',
+      dateDebut: watch('dateDebut') || '',
+      dateFin: watch('dateFin'),
+      dateCreation: chantier?.dateCreation || new Date().toISOString(),
+      salaries: chantierSalaries,
+      materiaux: chantierMateriaux,
+      sousTraitants: chantierSousTraitants,
+      fraisGeneraux: watch('fraisGeneraux') || 15,
+      margeObjectif: watch('margeObjectif') || 20,
+      coutMainOeuvre: 0,
+      coutMateriaux: 0,
+      coutSousTraitance: 0,
+      coutTotal: 0,
+      prixVenteHT: watch('prixVenteHT'),
+      prixVenteTTC: watch('prixVenteTTC'),
+      status: watch('status') || 'prospect',
+      echeancier: chantier?.echeancier || [],
+      tags: watch('tags') || [],
+      notes: watch('notes'),
+      version: chantier?.version || 1
+    };
+
+    return calculerCoutsChantier(chantierTemp, salaries, materiaux, sousTraitants);
+  }, [chantierSalaries, chantierMateriaux, chantierSousTraitants, watch, chantier, salaries, materiaux, sousTraitants]);
+
+  // Gestion des salariés
+  const ajouterSalarieChantier = () => {
+    if (!selectedSalarieId) return;
+
+    const nouveauChantierSalarie = {
+      salarieId: selectedSalarieId,
+      presences: [],
+      coutTotal: 0
+    };
+
+    setChantierSalaries([...chantierSalaries, nouveauChantierSalarie]);
+    setSelectedSalarieId('');
+    setShowSalarieForm(false);
+    
+    addToast({
+      type: 'success',
+      title: 'Salarié ajouté',
+      description: 'Le salarié a été ajouté au chantier'
+    });
+  };
+
+  const ajouterPresence = (salarieId: string) => {
+    if (!newPresence.date || !newPresence.heuresPresence) return;
+
+    const presence = {
+      date: newPresence.date,
+      heuresPresence: parseFloat(newPresence.heuresPresence),
+      heuresSupplementaires: parseFloat(newPresence.heuresSupplementaires) || 0,
+      tacheDescription: newPresence.tacheDescription || undefined,
+      commentaire: newPresence.commentaire || undefined
+    };
+
+    setChantierSalaries(prev => prev.map(cs => {
+      if (cs.salarieId === salarieId) {
+        const nouvelles = [...cs.presences, presence];
+        const salarie = salaries.find(s => s.id === salarieId);
+        if (salarie) {
+          const totalHeures = nouvelles.reduce((sum, p) => sum + p.heuresPresence, 0);
+          const totalHeuresSupp = nouvelles.reduce((sum, p) => sum + p.heuresSupplementaires, 0);
+          const coutTotal = calculerCoutChantierSalarie(salarie.tauxHoraire, totalHeures, totalHeuresSupp);
+          return { ...cs, presences: nouvelles, coutTotal };
+        }
+      }
+      return cs;
+    }));
+
+    setNewPresence({
+      date: '',
+      heuresPresence: '8',
+      heuresSupplementaires: '0',
+      tacheDescription: '',
+      commentaire: ''
+    });
+    setShowPresenceForm(null);
+    
+    addToast({
+      type: 'success',
+      title: 'Présence ajoutée',
+      description: 'La journée de travail a été enregistrée'
+    });
+  };
+
+  // Gestion des matériaux
+  const ajouterMateriauChantier = () => {
+    if (!newMateriau.materiauId || !newMateriau.quantite) return;
+
+    const materiau = materiaux.find(m => m.id === newMateriau.materiauId);
+    if (!materiau) return;
+
+    const quantite = parseFloat(newMateriau.quantite);
+    const prixUnitaire = newMateriau.prixUnitaireReel 
+      ? parseFloat(newMateriau.prixUnitaireReel)
+      : materiau.prixUnitaire;
+    
+    const coutHT = prixUnitaire * quantite;
+    const tva = coutHT * (parseFloat(newMateriau.tauxTVA) / 100);
+    const coutTTC = coutHT + tva;
+
+    const chantierMateriau = {
+      materiauId: newMateriau.materiauId,
+      quantite,
+      prixUnitaireReel: newMateriau.prixUnitaireReel ? prixUnitaire : undefined,
+      tauxTVA: newMateriau.tauxTVA,
+      coutHT,
+      coutTTC
+    };
+
+    setChantierMateriaux([...chantierMateriaux, chantierMateriau]);
+    setNewMateriau({
+      materiauId: '',
+      quantite: '',
+      prixUnitaireReel: '',
+      tauxTVA: '20'
+    });
+    setShowMateriauForm(false);
+    
+    addToast({
+      type: 'success',
+      title: 'Matériau ajouté',
+      description: 'Le matériau a été ajouté au chantier'
+    });
+  };
+
+  // Gestion des sous-traitants
+  const ajouterSousTraitantChantier = () => {
+    if (!newSousTraitant.sousTraitantId || !newSousTraitant.description || !newSousTraitant.montantForfait) return;
+
+    const chantierSousTraitant = {
+      sousTraitantId: newSousTraitant.sousTraitantId,
+      description: newSousTraitant.description,
+      dateDebut: newSousTraitant.dateDebut,
+      dateFin: newSousTraitant.dateFin || undefined,
+      montantForfait: parseFloat(newSousTraitant.montantForfait),
+      coutTotal: parseFloat(newSousTraitant.montantForfait),
+      statut: 'prevu' as const,
+      notes: newSousTraitant.notes || undefined
+    };
+
+    setChantierSousTraitants([...chantierSousTraitants, chantierSousTraitant]);
+    setNewSousTraitant({
+      sousTraitantId: '',
+      description: '',
+      dateDebut: '',
+      dateFin: '',
+      montantForfait: '',
+      notes: ''
+    });
+    setShowSousTraitantForm(false);
+    
+    addToast({
+      type: 'success',
+      title: 'Sous-traitant ajouté',
+      description: 'La prestation a été ajoutée au chantier'
+    });
+  };
+
+  const onSubmit = (data: ChantierFormData) => {
+    const chantierComplet: Chantier = {
+      id: chantier?.id || Date.now().toString(),
+      ...data,
+      dateCreation: chantier?.dateCreation || new Date().toISOString(),
+      salaries: chantierSalaries,
+      materiaux: chantierMateriaux,
+      sousTraitants: chantierSousTraitants,
+      coutMainOeuvre: couts.coutMainOeuvre,
+      coutMateriaux: couts.coutMateriaux,
+      coutSousTraitance: couts.coutSousTraitance,
+      coutTotal: couts.coutTotal,
+      margeReelle: couts.margeReelle,
+      echeancier: chantier?.echeancier || [],
+      version: chantier?.version || 1
+    };
+
+    onSave(chantierComplet);
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-lg font-semibold text-gray-800">
+          {isEditing ? 'Modifier le chantier' : 'Nouveau chantier'}
+        </h3>
+        <button
+          onClick={onCancel}
+          className="text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {/* Informations générales */}
+        <div className="bg-gray-50 rounded-lg p-4">
+          <h4 className="font-medium text-gray-800 mb-4">Informations générales</h4>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Référence *
+              </label>
+              <input
+                {...register('reference')}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="CH2024001"
+              />
+              {errors.reference && (
+                <p className="text-red-600 text-sm mt-1">{errors.reference.message}</p>
+              )}
+            </div>
+            
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Nom du chantier *
+              </label>
+              <input
+                {...register('nom')}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="Rénovation maison Dupont"
+              />
+              {errors.nom && (
+                <p className="text-red-600 text-sm mt-1">{errors.nom.message}</p>
+              )}
+            </div>
+          </div>
+
+          {/* Informations client */}
+          <div className="mt-4">
+            <h5 className="font-medium text-gray-700 mb-3">Client</h5>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Nom du client *
+                </label>
+                <input
+                  {...register('client.nom')}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="M. Dupont"
+                />
+                {errors.client?.nom && (
+                  <p className="text-red-600 text-sm mt-1">{errors.client.nom.message}</p>
+                )}
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Téléphone
+                </label>
+                <input
+                  {...register('client.telephone')}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="06 12 34 56 78"
+                />
+              </div>
+            </div>
+            
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Adresse client *
+                </label>
+                <input
+                  {...register('client.adresse')}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="123 rue de la Paix, Montpellier"
+                />
+                {errors.client?.adresse && (
+                  <p className="text-red-600 text-sm mt-1">{errors.client.adresse.message}</p>
+                )}
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Email
+                </label>
+                <input
+                  {...register('client.email')}
+                  type="email"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="client@email.com"
+                />
+                {errors.client?.email && (
+                  <p className="text-red-600 text-sm mt-1">{errors.client.email.message}</p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Détails chantier */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Adresse chantier *
+              </label>
+              <input
+                {...register('adresse')}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="456 avenue des Travaux, Montpellier"
+              />
+              {errors.adresse && (
+                <p className="text-red-600 text-sm mt-1">{errors.adresse.message}</p>
+              )}
+            </div>
+            
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Statut
+              </label>
+              <select
+                {...register('status')}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              >
+                <option value="prospect">Prospect</option>
+                <option value="devis">Devis envoyé</option>
+                <option value="en_cours">En cours</option>
+                <option value="livre">Livré</option>
+                <option value="facture">Facturé</option>
+                <option value="paye">Payé</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mt-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Date début *
+              </label>
+              <input
+                {...register('dateDebut')}
+                type="date"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+              {errors.dateDebut && (
+                <p className="text-red-600 text-sm mt-1">{errors.dateDebut.message}</p>
+              )}
+            </div>
+            
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Date fin
+              </label>
+              <input
+                {...register('dateFin')}
+                type="date"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+            
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Frais généraux (%)
+              </label>
+              <input
+                {...register('fraisGeneraux', { valueAsNumber: true })}
+                type="number"
+                step="0.1"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+            
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Marge objectif (%)
+              </label>
+              <input
+                {...register('margeObjectif', { valueAsNumber: true })}
+                type="number"
+                step="0.1"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Prix vente HT (€)
+              </label>
+              <input
+                {...register('prixVenteHT', { valueAsNumber: true })}
+                type="number"
+                step="0.01"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="Prix proposé au client"
+              />
+            </div>
+            
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Prix vente TTC (€)
+              </label>
+              <input
+                {...register('prixVenteTTC', { valueAsNumber: true })}
+                type="number"
+                step="0.01"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="Prix TTC client"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Section Main d'œuvre */}
+        <div className="bg-blue-50 rounded-lg p-4">
+          <div className="flex items-center justify-between mb-4">
+            <h4 className="text-md font-semibold text-gray-800 flex items-center">
+              <Clock className="h-5 w-5 text-blue-600 mr-2" />
+              Main d'œuvre - Suivi temps détaillé
+            </h4>
+            <button
+              type="button"
+              onClick={() => setShowSalarieForm(!showSalarieForm)}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Ajouter salarié
+            </button>
+          </div>
+
+          {showSalarieForm && (
+            <div className="bg-white rounded-lg p-4 mb-4 border border-blue-200">
+              <div className="flex items-center space-x-3">
+                <select
+                  value={selectedSalarieId}
+                  onChange={(e) => setSelectedSalarieId(e.target.value)}
+                  className="flex-1 px-3 py-2 border rounded-md focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="">Choisir un salarié</option>
+                  {salaries
+                    .filter(s => s.actif && !chantierSalaries.some(cs => cs.salarieId === s.id))
+                    .map((salarie) => (
+                      <option key={salarie.id} value={salarie.id}>
+                        {salarie.prenom} {salarie.nom} - {formatEuro(salarie.tauxHoraire)}/h
+                      </option>
+                    ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={ajouterSalarieChantier}
+                  disabled={!selectedSalarieId}
+                  className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 text-white px-4 py-2 rounded-md transition-colors"
+                >
+                  Ajouter
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Liste des salariés avec gestion des présences */}
+          {chantierSalaries.map((cs) => {
+            const salarie = salaries.find(s => s.id === cs.salarieId);
+            if (!salarie) return null;
+
+            const totalHeures = cs.presences.reduce((sum, p) => sum + p.heuresPresence, 0);
+            const totalHeuresSupp = cs.presences.reduce((sum, p) => sum + p.heuresSupplementaires, 0);
+            const nombreJours = cs.presences.length;
+
+            return (
+              <div key={cs.salarieId} className="bg-white rounded-lg border border-blue-200 p-4 mb-4">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center space-x-3">
+                    <div>
+                      <h5 className="font-semibold text-gray-800">
+                        {salarie.prenom} {salarie.nom}
+                      </h5>
+                      <p className="text-sm text-gray-600">
+                        {formatEuro(salarie.tauxHoraire)}/h • {nombreJours} jours • {totalHeures}h
+                        {totalHeuresSupp > 0 && ` (${totalHeuresSupp}h supp.)`}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-lg font-bold text-blue-600">
+                        {formatEuro(cs.coutTotal)}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowPresenceForm(showPresenceForm === cs.salarieId ? null : cs.salarieId)}
+                      className="bg-green-100 hover:bg-green-200 text-green-700 px-3 py-1 rounded-md text-sm transition-colors flex items-center"
+                    >
+                      <Clock className="h-4 w-4 mr-1" />
+                      {showPresenceForm === cs.salarieId ? 'Fermer' : 'Ajouter jour'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setChantierSalaries(prev => prev.filter(s => s.salarieId !== cs.salarieId))}
+                      className="text-red-600 hover:text-red-800 text-sm"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+
+                {/* Formulaire d'ajout de présence */}
+                {showPresenceForm === cs.salarieId && (
+                  <div className="bg-green-50 rounded-lg p-4 mb-4 border border-green-200">
+                    <h6 className="font-medium text-gray-800 mb-3">Ajouter une journée de travail</h6>
+                    <div className="grid grid-cols-1 md:grid-cols-6 gap-3">
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">Date</label>
+                        <input
+                          type="date"
+                          value={newPresence.date}
+                          onChange={(e) => setNewPresence({ ...newPresence, date: e.target.value })}
+                          className="w-full px-2 py-1 border rounded text-sm focus:ring-2 focus:ring-green-500"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">Heures</label>
+                        <input
+                          type="number"
+                          step="0.5"
+                          value={newPresence.heuresPresence}
+                          onChange={(e) => setNewPresence({ ...newPresence, heuresPresence: e.target.value })}
+                          className="w-full px-2 py-1 border rounded text-sm focus:ring-2 focus:ring-green-500"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">H. supp.</label>
+                        <input
+                          type="number"
+                          step="0.5"
+                          value={newPresence.heuresSupplementaires}
+                          onChange={(e) => setNewPresence({ ...newPresence, heuresSupplementaires: e.target.value })}
+                          className="w-full px-2 py-1 border rounded text-sm focus:ring-2 focus:ring-green-500"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">Tâche</label>
+                        <input
+                          type="text"
+                          value={newPresence.tacheDescription}
+                          onChange={(e) => setNewPresence({ ...newPresence, tacheDescription: e.target.value })}
+                          placeholder="Maçonnerie"
+                          className="w-full px-2 py-1 border rounded text-sm focus:ring-2 focus:ring-green-500"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">Commentaire</label>
+                        <input
+                          type="text"
+                          value={newPresence.commentaire}
+                          onChange={(e) => setNewPresence({ ...newPresence, commentaire: e.target.value })}
+                          placeholder="Optionnel"
+                          className="w-full px-2 py-1 border rounded text-sm focus:ring-2 focus:ring-green-500"
+                        />
+                      </div>
+                      <div className="flex items-end">
+                        <button
+                          type="button"
+                          onClick={() => ajouterPresence(cs.salarieId)}
+                          className="w-full bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded text-sm transition-colors flex items-center justify-center"
+                        >
+                          <Save className="h-3 w-3 mr-1" />
+                          Ajouter
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Liste des présences */}
+                {cs.presences.length > 0 && (
+                  <div className="space-y-2">
+                    <h6 className="text-sm font-medium text-gray-700">Présences enregistrées:</h6>
+                    <div className="max-h-40 overflow-y-auto space-y-1">
+                      {cs.presences.map((presence, index) => (
+                        <div key={index} className="flex items-center justify-between bg-gray-50 p-2 rounded text-sm">
+                          <div className="flex items-center space-x-3">
+                            <span className="font-medium">
+                              {new Date(presence.date).toLocaleDateString('fr-FR', { 
+                                weekday: 'short', 
+                                day: '2-digit', 
+                                month: '2-digit' 
+                              })}
+                            </span>
+                            <span className="text-blue-600">
+                              {presence.heuresPresence}h
+                              {presence.heuresSupplementaires > 0 && (
+                                <span className="text-orange-600"> +{presence.heuresSupplementaires}h supp.</span>
+                              )}
+                            </span>
+                            {presence.tacheDescription && (
+                              <span className="text-purple-600 text-xs bg-purple-100 px-2 py-1 rounded">
+                                {presence.tacheDescription}
+                              </span>
+                            )}
+                            {presence.commentaire && (
+                              <span className="text-gray-500 italic">"{presence.commentaire}"</span>
+                            )}
+                          </div>
+                          <div className="flex items-center space-x-2">
+                            <span className="font-medium text-green-600">
+                              {formatEuro(calculerCoutChantierSalarie(
+                                salarie.tauxHoraire, 
+                                presence.heuresPresence, 
+                                presence.heuresSupplementaires
+                              ))}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setChantierSalaries(prev => prev.map(cs_inner => {
+                                  if (cs_inner.salarieId === cs.salarieId) {
+                                    const nouvelles = cs_inner.presences.filter((_, i) => i !== index);
+                                    const totalHeures = nouvelles.reduce((sum, p) => sum + p.heuresPresence, 0);
+                                    const totalHeuresSupp = nouvelles.reduce((sum, p) => sum + p.heuresSupplementaires, 0);
+                                    const coutTotal = calculerCoutChantierSalarie(salarie.tauxHoraire, totalHeures, totalHeuresSupp);
+                                    return { ...cs_inner, presences: nouvelles, coutTotal };
+                                  }
+                                  return cs_inner;
+                                }));
+                              }}
+                              className="text-red-600 hover:text-red-800"
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Section Matériaux */}
+        <div className="bg-orange-50 rounded-lg p-4">
+          <div className="flex items-center justify-between mb-4">
+            <h4 className="text-md font-semibold text-gray-800">Matériaux et fournitures</h4>
+            <button
+              type="button"
+              onClick={() => setShowMateriauForm(!showMateriauForm)}
+              className="bg-orange-600 hover:bg-orange-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Ajouter matériau
+            </button>
+          </div>
+
+          {showMateriauForm && (
+            <div className="bg-white rounded-lg p-4 mb-4 border border-orange-200">
+              <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+                <select
+                  value={newMateriau.materiauId}
+                  onChange={(e) => setNewMateriau({ ...newMateriau, materiauId: e.target.value })}
+                  className="px-3 py-2 border rounded-md focus:ring-2 focus:ring-orange-500"
+                >
+                  <option value="">Choisir un matériau</option>
+                  {materiaux.filter(m => m.actif).map((materiau) => (
+                    <option key={materiau.id} value={materiau.id}>
+                      {materiau.nom} ({formatEuro(materiau.prixUnitaire)}/{materiau.unite})
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={newMateriau.quantite}
+                  onChange={(e) => setNewMateriau({ ...newMateriau, quantite: e.target.value })}
+                  placeholder="Quantité"
+                  className="px-3 py-2 border rounded-md focus:ring-2 focus:ring-orange-500"
+                />
+                <input
+                  type="number"
+                  step="0.01"
+                  value={newMateriau.prixUnitaireReel}
+                  onChange={(e) => setNewMateriau({ ...newMateriau, prixUnitaireReel: e.target.value })}
+                  placeholder="Prix réel (opt.)"
+                  className="px-3 py-2 border rounded-md focus:ring-2 focus:ring-orange-500"
+                />
+                <select
+                  value={newMateriau.tauxTVA}
+                  onChange={(e) => setNewMateriau({ ...newMateriau, tauxTVA: e.target.value as any })}
+                  className="px-3 py-2 border rounded-md focus:ring-2 focus:ring-orange-500"
+                >
+                  <option value="5.5">TVA 5,5%</option>
+                  <option value="10">TVA 10%</option>
+                  <option value="20">TVA 20%</option>
+                </select>
+                <button
+                  type="button"
+                  onClick={ajouterMateriauChantier}
+                  disabled={!newMateriau.materiauId || !newMateriau.quantite}
+                  className="bg-orange-600 hover:bg-orange-700 disabled:bg-gray-300 text-white px-4 py-2 rounded-md transition-colors"
+                >
+                  Ajouter
+                </button>
+              </div>
+            </div>
+          )}
+
+          {chantierMateriaux.length > 0 && (
+            <div className="space-y-2">
+              {chantierMateriaux.map((cm, index) => {
+                const materiau = materiaux.find(m => m.id === cm.materiauId);
+                const prixUnitaire = cm.prixUnitaireReel || materiau?.prixUnitaire || 0;
+                return (
+                  <div key={index} className="flex items-center justify-between bg-white p-3 rounded-md border border-orange-200">
+                    <div className="flex-1">
+                      <span className="font-medium">{materiau?.nom}</span>
+                      <div className="text-sm text-gray-600">
+                        {cm.quantite} {materiau?.unite} × {formatEuro(prixUnitaire)} = {formatEuro(cm.coutHT)} HT
+                        <span className="ml-2 text-xs bg-gray-100 px-2 py-1 rounded">
+                          TVA {cm.tauxTVA}%: {formatEuro(cm.coutTTC - cm.coutHT)}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="text-right mr-4">
+                      <div className="font-semibold text-orange-600">{formatEuro(cm.coutTTC)} TTC</div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setChantierMateriaux(prev => prev.filter((_, i) => i !== index))}
+                      className="text-red-600 hover:text-red-800"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Section Sous-traitance */}
+        <div className="bg-purple-50 rounded-lg p-4">
+          <div className="flex items-center justify-between mb-4">
+            <h4 className="text-md font-semibold text-gray-800">Sous-traitance</h4>
+            <button
+              type="button"
+              onClick={() => setShowSousTraitantForm(!showSousTraitantForm)}
+              className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Ajouter prestation
+            </button>
+          </div>
+
+          {showSousTraitantForm && (
+            <div className="bg-white rounded-lg p-4 mb-4 border border-purple-200">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                <div className="md:col-span-2">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Sous-traitant
+                  </label>
+                  <select
+                    value={newSousTraitant.sousTraitantId}
+                    onChange={(e) => setNewSousTraitant({ ...newSousTraitant, sousTraitantId: e.target.value })}
+                    className="w-full px-3 py-2 border rounded-md focus:ring-2 focus:ring-purple-500"
+                  >
+                    <option value="">Choisir un sous-traitant</option>
+                    {sousTraitants.filter(st => st.actif).map((sousTraitant) => (
+                      <option key={sousTraitant.id} value={sousTraitant.id}>
+                        {sousTraitant.entreprise} - {sousTraitant.nom}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                
+                <div className="md:col-span-2">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Description de la prestation *
+                  </label>
+                  <input
+                    type="text"
+                    value={newSousTraitant.description}
+                    onChange={(e) => setNewSousTraitant({ ...newSousTraitant, description: e.target.value })}
+                    placeholder="Installation électrique complète"
+                    className="w-full px-3 py-2 border rounded-md focus:ring-2 focus:ring-purple-500"
+                  />
+                </div>
+                
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Date début
+                  </label>
+                  <input
+                    type="date"
+                    value={newSousTraitant.dateDebut}
+                    onChange={(e) => setNewSousTraitant({ ...newSousTraitant, dateDebut: e.target.value })}
+                    className="w-full px-3 py-2 border rounded-md focus:ring-2 focus:ring-purple-500"
+                  />
+                </div>
+                
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Date fin (optionnel)
+                  </label>
+                  <input
+                    type="date"
+                    value={newSousTraitant.dateFin}
+                    onChange={(e) => setNewSousTraitant({ ...newSousTraitant, dateFin: e.target.value })}
+                    className="w-full px-3 py-2 border rounded-md focus:ring-2 focus:ring-purple-500"
+                  />
+                </div>
+                
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Montant forfaitaire (€) *
+                  </label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    value={newSousTraitant.montantForfait}
+                    onChange={(e) => setNewSousTraitant({ ...newSousTraitant, montantForfait: e.target.value })}
+                    placeholder="1500.00"
+                    className="w-full px-3 py-2 border rounded-md focus:ring-2 focus:ring-purple-500"
+                  />
+                </div>
+                
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Notes (optionnel)
+                  </label>
+                  <input
+                    type="text"
+                    value={newSousTraitant.notes}
+                    onChange={(e) => setNewSousTraitant({ ...newSousTraitant, notes: e.target.value })}
+                    placeholder="Notes sur la prestation"
+                    className="w-full px-3 py-2 border rounded-md focus:ring-2 focus:ring-purple-500"
+                  />
+                </div>
+              </div>
+              
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={ajouterSousTraitantChantier}
+                  disabled={!newSousTraitant.sousTraitantId || !newSousTraitant.description || !newSousTraitant.montantForfait}
+                  className="bg-purple-600 hover:bg-purple-700 disabled:bg-gray-300 text-white px-4 py-2 rounded-md transition-colors"
+                >
+                  Ajouter la prestation
+                </button>
+              </div>
+            </div>
+          )}
+
+          {chantierSousTraitants.length > 0 && (
+            <div className="space-y-2">
+              {chantierSousTraitants.map((cst, index) => {
+                const sousTraitant = sousTraitants.find(st => st.id === cst.sousTraitantId);
+                return (
+                  <div key={index} className="flex items-center justify-between bg-white p-3 rounded-md border border-purple-200">
+                    <div className="flex-1">
+                      <div className="font-medium">{sousTraitant?.entreprise} - {sousTraitant?.nom}</div>
+                      <div className="text-sm text-gray-600">{cst.description}</div>
+                      <div className="text-xs text-gray-500">
+                        {cst.dateDebut && `Du ${new Date(cst.dateDebut).toLocaleDateString('fr-FR')}`}
+                        {cst.dateFin && ` au ${new Date(cst.dateFin).toLocaleDateString('fr-FR')}`}
+                        {cst.notes && ` • ${cst.notes}`}
+                      </div>
+                    </div>
+                    <div className="text-right mr-4">
+                      <div className="font-semibold text-purple-600">{formatEuro(cst.montantForfait)}</div>
+                      <div className="text-xs text-gray-500 capitalize">{cst.statut.replace('_', ' ')}</div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setChantierSousTraitants(prev => prev.filter((_, i) => i !== index))}
+                      className="text-red-600 hover:text-red-800"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Récapitulatif financier en temps réel */}
+        {(chantierSalaries.length > 0 || chantierMateriaux.length > 0 || chantierSousTraitants.length > 0) && (
+          <div className="bg-green-50 rounded-lg p-4 border border-green-200">
+            <div className="flex items-center mb-4">
+              <Calculator className="h-5 w-5 text-green-600 mr-2" />
+              <h4 className="font-semibold text-gray-800">Récapitulatif financier</h4>
+            </div>
+            
+            <div className="grid grid-cols-1 md:grid-cols-5 gap-4 text-sm">
+              <div className="bg-white rounded-lg p-3">
+                <span className="text-gray-600 block">Main d'œuvre:</span>
+                <div className="font-semibold text-blue-600 text-lg">{formatEuro(couts.coutMainOeuvre)}</div>
+                <div className="text-xs text-gray-500">
+                  {chantierSalaries.reduce((sum, cs) => sum + cs.presences.reduce((s, p) => s + p.heuresPresence, 0), 0)}h total
+                </div>
+              </div>
+              
+              <div className="bg-white rounded-lg p-3">
+                <span className="text-gray-600 block">Matériaux:</span>
+                <div className="font-semibold text-orange-600 text-lg">{formatEuro(couts.coutMateriaux)}</div>
+                <div className="text-xs text-gray-500">
+                  {chantierMateriaux.length} référence(s)
+                </div>
+              </div>
+              
+              <div className="bg-white rounded-lg p-3">
+                <span className="text-gray-600 block">Sous-traitance:</span>
+                <div className="font-semibold text-purple-600 text-lg">{formatEuro(couts.coutSousTraitance)}</div>
+                <div className="text-xs text-gray-500">
+                  {chantierSousTraitants.length} prestation(s)
+                </div>
+              </div>
+              
+              <div className="bg-white rounded-lg p-3">
+                <span className="text-gray-600 block">Frais généraux:</span>
+                <div className="font-semibold text-gray-600 text-lg">
+                  {formatEuro(couts.fraisGeneraux)}
+                </div>
+                <div className="text-xs text-gray-500">{watch('fraisGeneraux')}%</div>
+              </div>
+              
+              <div className="bg-white rounded-lg p-3 border-2 border-green-300">
+                <span className="text-gray-600 block">Coût total:</span>
+                <div className="font-bold text-green-600 text-xl">{formatEuro(couts.coutTotal)}</div>
+                {couts.margeReelle !== undefined && (
+                  <div className={`text-xs ${couts.margeReelle >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    Marge: {couts.margeReelle.toFixed(1)}%
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Prix de vente recommandé */}
+            <div className="mt-4 p-3 bg-blue-100 rounded-lg">
+              <div className="text-sm text-blue-800">
+                <strong>Prix de vente recommandé (marge {watch('margeObjectif')}%):</strong>
+                <span className="ml-2 font-bold">{formatEuro(couts.prixVenteRecommande)}</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Notes */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Notes et observations
+          </label>
+          <textarea
+            {...register('notes')}
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="Notes internes, spécificités du chantier..."
+          />
+        </div>
+
+        {/* Actions */}
+        <div className="flex space-x-4">
+          <button
+            type="submit"
+            className="flex-1 bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-md transition-colors duration-200 flex items-center justify-center"
+          >
+            <Save className="h-5 w-5 mr-2" />
+            {isEditing ? 'Sauvegarder les modifications' : 'Créer le chantier'}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-6 bg-gray-300 hover:bg-gray-400 text-gray-700 font-medium py-3 rounded-md transition-colors duration-200"
+          >
+            Annuler
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/components/Chantiers/ChantiersList.tsx
+++ b/src/components/Chantiers/ChantiersList.tsx
@@ -1,0 +1,350 @@
+import React from 'react';
+import { Edit, Trash2, FileText, Download, Calendar, MapPin, TrendingUp, Users, Package } from 'lucide-react';
+import { Chantier, Salarie, Materiau } from '../../schemas';
+import { DataTable } from '../UI/DataTable';
+import { calculerCoutsChantier } from '../../services/costEngine';
+import { formatEuro } from '../../utils/calculsFiscaux';
+
+interface ChantiersListProps {
+  chantiers: Chantier[];
+  salaries: Salarie[];
+  materiaux: Materiau[];
+  onEdit: (chantier: Chantier) => void;
+  onDelete: (id: string) => void;
+  onGenerateDevis: (chantier: Chantier) => void;
+}
+
+export const ChantiersList: React.FC<ChantiersListProps> = ({
+  chantiers,
+  salaries,
+  materiaux,
+  onEdit,
+  onDelete,
+  onGenerateDevis
+}) => {
+  const getStatusBadge = (status: Chantier['status']) => {
+    const styles = {
+      'prospect': 'bg-gray-100 text-gray-800',
+      'devis': 'bg-yellow-100 text-yellow-800',
+      'en_cours': 'bg-blue-100 text-blue-800',
+      'livre': 'bg-green-100 text-green-800',
+      'facture': 'bg-purple-100 text-purple-800',
+      'paye': 'bg-green-100 text-green-800'
+    };
+    
+    const labels = {
+      'prospect': 'Prospect',
+      'devis': 'Devis envoyé',
+      'en_cours': 'En cours',
+      'livre': 'Livré',
+      'facture': 'Facturé',
+      'paye': 'Payé'
+    };
+
+    return (
+      <span className={`px-2 py-1 rounded-full text-xs font-medium ${styles[status]}`}>
+        {labels[status]}
+      </span>
+    );
+  };
+
+  const columns = [
+    {
+      key: 'reference',
+      header: 'Référence',
+      sortable: true,
+      render: (chantier: Chantier) => (
+        <div>
+          <div className="font-medium text-gray-900">{chantier.reference}</div>
+          <div className="text-sm text-gray-500">{chantier.nom}</div>
+        </div>
+      )
+    },
+    {
+      key: 'client',
+      header: 'Client',
+      sortable: true,
+      render: (chantier: Chantier) => (
+        <div>
+          <div className="font-medium text-gray-900">{chantier.client.nom}</div>
+          <div className="text-sm text-gray-500">{chantier.adresse}</div>
+        </div>
+      )
+    },
+    {
+      key: 'dateDebut',
+      header: 'Période',
+      sortable: true,
+      render: (chantier: Chantier) => (
+        <div className="text-sm">
+          <div className="flex items-center text-gray-900">
+            <Calendar className="h-3 w-3 mr-1" />
+            {new Date(chantier.dateDebut).toLocaleDateString('fr-FR')}
+          </div>
+          {chantier.dateFin && (
+            <div className="text-gray-500">
+              → {new Date(chantier.dateFin).toLocaleDateString('fr-FR')}
+            </div>
+          )}
+        </div>
+      )
+    },
+    {
+      key: 'status',
+      header: 'Statut',
+      sortable: true,
+      render: (chantier: Chantier) => getStatusBadge(chantier.status)
+    },
+    {
+      key: 'coutTotal',
+      header: 'Coût',
+      sortable: true,
+      render: (chantier: Chantier) => {
+        const couts = calculerCoutsChantier(chantier, salaries, materiaux);
+        return (
+          <div className="text-right">
+            <div className="font-semibold text-gray-900">{formatEuro(couts.coutTotal)}</div>
+            {couts.margeReelle !== undefined && (
+              <div className={`text-xs ${couts.margeReelle >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                {couts.margeReelle.toFixed(1)}% marge
+              </div>
+            )}
+          </div>
+        );
+      }
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (chantier: Chantier) => (
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit(chantier);
+            }}
+            className="text-blue-600 hover:text-blue-800 transition-colors"
+            title="Modifier"
+          >
+            <Edit className="h-4 w-4" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onGenerateDevis(chantier);
+            }}
+            className="text-green-600 hover:text-green-800 transition-colors"
+            title="Générer devis"
+          >
+            <FileText className="h-4 w-4" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(chantier.id);
+            }}
+            className="text-red-600 hover:text-red-800 transition-colors"
+            title="Supprimer"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      )
+    }
+  ];
+
+  return (
+    <div className="space-y-6">
+      {/* Vue tableau */}
+      <DataTable
+        data={chantiers}
+        columns={columns}
+        searchPlaceholder="Rechercher par référence, nom, client..."
+        emptyMessage="Aucun chantier créé"
+        onRowClick={(chantier) => {
+          // Optionnel: ouvrir les détails en cliquant sur la ligne
+        }}
+      />
+
+      {/* Vue détaillée (cartes) */}
+      <div className="space-y-4">
+        {chantiers.map((chantier) => {
+          const couts = calculerCoutsChantier(chantier, salaries, materiaux);
+          
+          return (
+            <div key={chantier.id} className="bg-white rounded-lg shadow-md overflow-hidden">
+              <div className="px-6 py-4 bg-gradient-to-r from-green-50 to-blue-50 border-b">
+                <div className="flex items-center justify-between">
+                  <div className="flex-1">
+                    <div className="flex items-center space-x-3 mb-2">
+                      <h4 className="text-lg font-semibold text-gray-800">{chantier.nom}</h4>
+                      <span className="text-sm text-gray-500">({chantier.reference})</span>
+                      {getStatusBadge(chantier.status)}
+                    </div>
+                    <div className="flex items-center text-sm text-gray-600 space-x-4">
+                      <div className="flex items-center">
+                        <MapPin className="h-4 w-4 mr-1" />
+                        {chantier.client.nom} - {chantier.adresse}
+                      </div>
+                      <div className="flex items-center">
+                        <Calendar className="h-4 w-4 mr-1" />
+                        {new Date(chantier.dateDebut).toLocaleDateString('fr-FR')}
+                        {chantier.dateFin && ` - ${new Date(chantier.dateFin).toLocaleDateString('fr-FR')}`}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <button
+                      onClick={() => onEdit(chantier)}
+                      className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-md text-sm transition-colors flex items-center"
+                    >
+                      <Edit className="h-4 w-4 mr-1" />
+                      Modifier
+                    </button>
+                    <button
+                      onClick={() => onGenerateDevis(chantier)}
+                      className="bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded-md text-sm transition-colors flex items-center"
+                    >
+                      <FileText className="h-4 w-4 mr-1" />
+                      Devis
+                    </button>
+                    <button
+                      onClick={() => onDelete(chantier.id)}
+                      className="bg-red-600 hover:bg-red-700 text-white px-3 py-2 rounded-md text-sm transition-colors flex items-center"
+                    >
+                      <Trash2 className="h-4 w-4 mr-1" />
+                      Supprimer
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="p-6">
+                {/* Résumé financier */}
+                <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+                  <div className="bg-blue-50 rounded-lg p-4">
+                    <div className="flex items-center mb-2">
+                      <Users className="h-5 w-5 text-blue-600 mr-2" />
+                      <span className="text-sm font-medium text-gray-700">Main d'œuvre</span>
+                    </div>
+                    <div className="text-lg font-bold text-blue-600">
+                      {formatEuro(couts.coutMainOeuvre)}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      {chantier.salaries.reduce((sum, cs) => sum + cs.presences.length, 0)} jours-homme
+                    </div>
+                  </div>
+                  
+                  <div className="bg-orange-50 rounded-lg p-4">
+                    <div className="flex items-center mb-2">
+                      <Package className="h-5 w-5 text-orange-600 mr-2" />
+                      <span className="text-sm font-medium text-gray-700">Matériaux</span>
+                    </div>
+                    <div className="text-lg font-bold text-orange-600">
+                      {formatEuro(couts.coutMateriaux)}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      {chantier.materiaux.length} référence(s)
+                    </div>
+                  </div>
+                  
+                  <div className="bg-gray-50 rounded-lg p-4">
+                    <div className="text-sm font-medium text-gray-700 mb-2">Frais généraux</div>
+                    <div className="text-lg font-bold text-gray-600">
+                      {formatEuro(couts.fraisGeneraux)}
+                    </div>
+                    <div className="text-xs text-gray-500">{chantier.fraisGeneraux}%</div>
+                  </div>
+                  
+                  <div className="bg-green-50 rounded-lg p-4">
+                    <div className="text-sm font-medium text-gray-700 mb-2">Coût total</div>
+                    <div className="text-xl font-bold text-green-600">
+                      {formatEuro(couts.coutTotal)}
+                    </div>
+                  </div>
+                  
+                  {couts.margeReelle !== undefined && (
+                    <div className={`rounded-lg p-4 ${couts.margeReelle >= 0 ? 'bg-green-50' : 'bg-red-50'}`}>
+                      <div className="flex items-center mb-2">
+                        <TrendingUp className={`h-5 w-5 mr-2 ${couts.margeReelle >= 0 ? 'text-green-600' : 'text-red-600'}`} />
+                        <span className="text-sm font-medium text-gray-700">Marge</span>
+                      </div>
+                      <div className={`text-lg font-bold ${couts.margeReelle >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {couts.margeReelle.toFixed(1)}%
+                      </div>
+                      {chantier.prixVenteHT && (
+                        <div className="text-xs text-gray-500">
+                          Prix: {formatEuro(chantier.prixVenteHT)}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {/* Détail des présences par salarié */}
+                {chantier.salaries.some(cs => cs.presences.length > 0) && (
+                  <div className="mt-6">
+                    <h5 className="text-md font-semibold text-gray-800 mb-3 flex items-center">
+                      <Calendar className="h-4 w-4 mr-2" />
+                      Détail des présences
+                    </h5>
+                    <div className="space-y-3">
+                      {chantier.salaries.filter(cs => cs.presences.length > 0).map((cs) => {
+                        const salarie = salaries.find(s => s.id === cs.salarieId);
+                        const totalHeures = cs.presences.reduce((sum, p) => sum + p.heuresPresence, 0);
+                        const totalHeuresSupp = cs.presences.reduce((sum, p) => sum + p.heuresSupplementaires, 0);
+                        
+                        return (
+                          <div key={cs.salarieId} className="bg-blue-50 rounded-lg p-4">
+                            <div className="flex items-center justify-between mb-3">
+                              <div className="font-medium text-sm text-gray-800">
+                                {salarie?.prenom} {salarie?.nom}
+                              </div>
+                              <div className="text-sm text-blue-600 font-semibold">
+                                {cs.presences.length} jours • {totalHeures}h
+                                {totalHeuresSupp > 0 && ` (+${totalHeuresSupp}h supp.)`}
+                                • {formatEuro(cs.coutTotal)}
+                              </div>
+                            </div>
+                            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-2 text-xs">
+                              {cs.presences.map((presence, pIndex) => (
+                                <div key={pIndex} className="bg-white rounded p-2 border">
+                                  <div className="font-medium">
+                                    {new Date(presence.date).toLocaleDateString('fr-FR', { 
+                                      day: '2-digit', 
+                                      month: '2-digit' 
+                                    })}
+                                  </div>
+                                  <div className="text-blue-600">
+                                    {presence.heuresPresence}h
+                                    {presence.heuresSupplementaires > 0 && (
+                                      <span className="text-orange-600"> +{presence.heuresSupplementaires}h</span>
+                                    )}
+                                  </div>
+                                  {presence.tacheDescription && (
+                                    <div className="text-purple-600 text-xs bg-purple-100 px-1 rounded mt-1">
+                                      {presence.tacheDescription}
+                                    </div>
+                                  )}
+                                  {presence.commentaire && (
+                                    <div className="text-gray-500 italic truncate mt-1" title={presence.commentaire}>
+                                      {presence.commentaire}
+                                    </div>
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Chantiers/ChantiersManager.tsx
+++ b/src/components/Chantiers/ChantiersManager.tsx
@@ -1,0 +1,199 @@
+import React, { useState } from 'react';
+import { Plus, Download, Upload, RotateCcw } from 'lucide-react';
+import { Chantier, Salarie, Materiau, SousTraitant } from '../../schemas';
+import { ChantierForm } from './ChantierForm';
+import { ChantiersList } from './ChantiersList';
+import { useToast } from '../UI/Toast';
+import { exportToJSON, genererNumeroDevis } from '../../services/importExportService';
+import { genererDevisPDF } from '../../services/pdfService';
+
+interface ChantiersManagerProps {
+  chantiers: Chantier[];
+  setChantiers: (chantiers: Chantier[]) => boolean;
+  salaries: Salarie[];
+  materiaux: Materiau[];
+  sousTraitants: SousTraitant[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const ChantiersManager: React.FC<ChantiersManagerProps> = ({
+  chantiers,
+  setChantiers,
+  salaries,
+  materiaux,
+  sousTraitants,
+  isLoading,
+  error
+}) => {
+  const [showForm, setShowForm] = useState(false);
+  const [editingChantier, setEditingChantier] = useState<Chantier | null>(null);
+  const { addToast } = useToast();
+
+  const ajouterChantier = (nouveauChantier: Chantier) => {
+    const success = setChantiers([...chantiers, nouveauChantier]);
+    if (success) {
+      addToast({
+        type: 'success',
+        title: 'Chantier créé',
+        description: `Le chantier "${nouveauChantier.nom}" a été créé avec succès`
+      });
+      setShowForm(false);
+    } else {
+      addToast({
+        type: 'error',
+        title: 'Erreur',
+        description: 'Impossible de créer le chantier'
+      });
+    }
+  };
+
+  const modifierChantier = (chantierModifie: Chantier) => {
+    const nouveauxChantiers = chantiers.map(c => 
+      c.id === chantierModifie.id ? { ...chantierModifie, version: c.version + 1 } : c
+    );
+    const success = setChantiers(nouveauxChantiers);
+    
+    if (success) {
+      addToast({
+        type: 'success',
+        title: 'Chantier modifié',
+        description: `Le chantier "${chantierModifie.nom}" a été mis à jour`
+      });
+      setEditingChantier(null);
+    } else {
+      addToast({
+        type: 'error',
+        title: 'Erreur',
+        description: 'Impossible de modifier le chantier'
+      });
+    }
+  };
+
+  const supprimerChantier = (id: string) => {
+    const chantier = chantiers.find(c => c.id === id);
+    if (!chantier) return;
+
+    if (window.confirm(`Êtes-vous sûr de vouloir supprimer le chantier "${chantier.nom}" ?`)) {
+      const success = setChantiers(chantiers.filter(c => c.id !== id));
+      if (success) {
+        addToast({
+          type: 'success',
+          title: 'Chantier supprimé',
+          description: `Le chantier "${chantier.nom}" a été supprimé`
+        });
+      }
+    }
+  };
+
+  const exporterDonnees = () => {
+    exportToJSON({ salaries, materiaux, sousTraitants, chantiers });
+    addToast({
+      type: 'success',
+      title: 'Export réussi',
+      description: 'Les données ont été exportées'
+    });
+  };
+
+  const genererDevis = (chantier: Chantier) => {
+    const numeroDevis = genererNumeroDevis(chantiers);
+    const pdf = genererDevisPDF(chantier, salaries, materiaux, sousTraitants, numeroDevis);
+    pdf.save(`devis-${chantier.reference || chantier.id}.pdf`);
+    
+    addToast({
+      type: 'success',
+      title: 'Devis généré',
+      description: `Devis ${numeroDevis} téléchargé`
+    });
+  };
+
+  const resetDonnees = () => {
+    if (window.confirm('Êtes-vous sûr de vouloir réinitialiser tous les chantiers ? Cette action est irréversible.')) {
+      const success = setChantiers([]);
+      if (success) {
+        addToast({
+          type: 'success',
+          title: 'Données réinitialisées',
+          description: 'Tous les chantiers ont été supprimés'
+        });
+      }
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+        <p className="text-red-800">Erreur: {error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Actions globales */}
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-800">Gestion des chantiers</h2>
+          <div className="flex items-center space-x-3">
+            <button
+              onClick={exporterDonnees}
+              className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Download className="h-4 w-4 mr-2" />
+              Exporter
+            </button>
+            <button
+              onClick={resetDonnees}
+              className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <RotateCcw className="h-4 w-4 mr-2" />
+              Reset
+            </button>
+            <button
+              onClick={() => setShowForm(!showForm)}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Nouveau chantier
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Formulaire de création/édition */}
+      {(showForm || editingChantier) && (
+        <ChantierForm
+          chantier={editingChantier}
+          salaries={salaries}
+          materiaux={materiaux}
+          sousTraitants={sousTraitants}
+          sousTraitants={sousTraitants}
+          onSave={editingChantier ? modifierChantier : ajouterChantier}
+          onCancel={() => {
+            setShowForm(false);
+            setEditingChantier(null);
+          }}
+        />
+      )}
+
+      {/* Liste des chantiers */}
+      <ChantiersList
+        chantiers={chantiers}
+        salaries={salaries}
+        materiaux={materiaux}
+        sousTraitants={sousTraitants}
+        onEdit={setEditingChantier}
+        onDelete={supprimerChantier}
+        onGenerateDevis={genererDevis}
+      />
+    </div>
+  );
+};

--- a/src/components/Chantiers/EstimationForm.tsx
+++ b/src/components/Chantiers/EstimationForm.tsx
@@ -1,0 +1,265 @@
+import React, { useState } from 'react';
+import { PlusCircle, MinusCircle, Calculator, Save, X, ArrowRight } from 'lucide-react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useToast } from '../UI/Toast';
+import { EstimationRequest, EstimationChantier, PosteTravail, obtenirEstimation } from '../../services/estimationAPI';
+import { formatEuro } from '../../utils/calculsFiscaux';
+
+// Schéma de validation pour le formulaire d'estimation
+const EstimationFormSchema = z.object({
+  reference: z.string().min(1, 'La référence est requise'),
+  nom: z.string().min(1, 'Le nom du chantier est requis'),
+  adresse: z.string().min(1, 'L\'adresse est requise'),
+  surface: z.number().min(1, 'La surface doit être supérieure à 0'),
+  typeConstruction: z.enum([
+    'maison_individuelle', 
+    'appartement', 
+    'immeuble', 
+    'local_commercial',
+    'batiment_industriel',
+    'renovation',
+    'extension'
+  ]),
+  postes: z.array(z.object({
+    id: z.string(),
+    nom: z.string().min(1, 'Le nom du poste est requis'),
+    description: z.string(),
+    unite: z.string().min(1, 'L\'unité est requise'),
+    quantite: z.number().min(0.1, 'La quantité doit être supérieure à 0')
+  })).min(1, 'Au moins un poste de travail est requis'),
+  commentaires: z.string().optional(),
+  options: z.object({
+    qualite: z.enum(['standard', 'premium', 'luxe']).default('standard'),
+    delai: z.enum(['normal', 'urgent', 'tres_urgent']).default('normal'),
+    difficulte: z.enum(['facile', 'moyen', 'difficile']).default('facile')
+  })
+});
+
+type EstimationFormData = z.infer<typeof EstimationFormSchema>;
+
+interface EstimationFormProps {
+  onSaveEstimation: (estimation: EstimationChantier) => void;
+  onCancel: () => void;
+}
+
+export const EstimationForm: React.FC<EstimationFormProps> = ({ onSaveEstimation, onCancel }) => {
+  const { addToast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [estimation, setEstimation] = useState<EstimationChantier | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors }
+  } = useForm<EstimationFormData>({
+    resolver: zodResolver(EstimationFormSchema),
+    defaultValues: {
+      reference: `EST${Date.now().toString().slice(-6)}`,
+      nom: '',
+      adresse: '',
+      surface: 0,
+      typeConstruction: 'maison_individuelle',
+      postes: [
+        {
+          id: `poste_${Date.now()}`,
+          nom: 'Gros œuvre',
+          description: 'Fondations, murs porteurs, planchers',
+          unite: 'm²',
+          quantite: 0
+        }
+      ],
+      commentaires: '',
+      options: {
+        qualite: 'standard',
+        delai: 'normal',
+        difficulte: 'facile'
+      }
+    }
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'postes'
+  });
+
+  const ajouterPoste = () => {
+    append({
+      id: `poste_${Date.now()}`,
+      nom: '',
+      description: '',
+      unite: 'm²',
+      quantite: 0
+    });
+  };
+
+  const onSubmit = async (data: EstimationFormData) => {
+    setIsLoading(true);
+    try {
+      const request: EstimationRequest = {
+        reference: data.reference,
+        nom: data.nom,
+        adresse: data.adresse,
+        surface: data.surface,
+        typeConstruction: data.typeConstruction,
+        postes: data.postes,
+        commentaires: data.commentaires,
+        options: data.options
+      };
+
+      const resultat = await obtenirEstimation(request);
+      setEstimation(resultat);
+      addToast({
+        type: 'success',
+        title: 'Estimation réussie',
+        description: 'L\'estimation du chantier a été calculée avec succès'
+      });
+    } catch (error) {
+      addToast({
+        type: 'error',
+        title: 'Erreur d\'estimation',
+        description: error instanceof Error ? error.message : 'Une erreur est survenue'
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const sauvegarderEstimation = () => {
+    if (estimation) {
+      onSaveEstimation(estimation);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-lg font-semibold text-gray-800">
+          Estimation de chantier
+        </h3>
+        <button
+          onClick={onCancel}
+          className="text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      {!estimation ? (
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          {/* Informations générales */}
+          <div className="bg-gray-50 rounded-lg p-4">
+            <h4 className="font-medium text-gray-800 mb-4">Informations générales</h4>
+            
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Référence *
+                </label>
+                <input
+                  {...register('reference')}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="EST001"
+                />
+                {errors.reference && (
+                  <p className="text-red-600 text-sm mt-1">{errors.reference.message}</p>
+                )}
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Nom du chantier *
+                </label>
+                <input
+                  {...register('nom')}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="Rénovation maison Dupont"
+                />
+                {errors.nom && (
+                  <p className="text-red-600 text-sm mt-1">{errors.nom.message}</p>
+                )}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Adresse du chantier *
+                </label>
+                <input
+                  {...register('adresse')}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="123 rue de la Paix, 75000 Paris"
+                />
+                {errors.adresse && (
+                  <p className="text-red-600 text-sm mt-1">{errors.adresse.message}</p>
+                )}
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Type de construction *
+                </label>
+                <select
+                  {...register('typeConstruction')}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option value="maison_individuelle">Maison individuelle</option>
+                  <option value="appartement">Appartement</option>
+                  <option value="immeuble">Immeuble</option>
+                  <option value="local_commercial">Local commercial</option>
+                  <option value="batiment_industriel">Bâtiment industriel</option>
+                  <option value="renovation">Rénovation</option>
+                  <option value="extension">Extension</option>
+                </select>
+                {errors.typeConstruction && (
+                  <p className="text-red-600 text-sm mt-1">{errors.typeConstruction.message}</p>
+                )}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Surface (m²) *
+                </label>
+                <input
+                  {...register('surface', { valueAsNumber: true })}
+                  type="number"
+                  step="0.1"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="100"
+                />
+                {errors.surface && (
+                  <p className="text-red-600 text-sm mt-1">{errors.surface.message}</p>
+                )}
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Qualité des matériaux
+                </label>
+                <select
+                  {...register('options.qualite')}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option value="standard">Standard</option>
+                  <option value="premium">Premium</option>
+                  <option value="luxe">Luxe</option>
+                </select>
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Délai d'exécution
+                </label>
+                <select
+                  {...register('options.delai')}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option value="normal">Normal</option>
+                  <option value="urgent">Urgent</option>
+                  <option value="tres_urgent">Très urgent</option>
+                </select>

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { BarChart3, TrendingUp, Users, Package, MapPin, AlertTriangle, CheckCircle, Clock } from 'lucide-react';
+import { Chantier, Salarie, Materiau } from '../../schemas';
+import { useKPI } from '../../hooks/useKPI';
+import { formatEuro, formatPourcentage } from '../../utils/calculsFiscaux';
+
+interface DashboardProps {
+  chantiers: Chantier[];
+  salaries: Salarie[];
+  materiaux: Materiau[];
+}
+
+export const Dashboard: React.FC<DashboardProps> = ({ chantiers, salaries, materiaux }) => {
+  const kpi = useKPI(chantiers, salaries, materiaux);
+
+  return (
+    <div className="space-y-6">
+      {/* Alertes */}
+      {kpi.alertes.length > 0 && (
+        <div className="space-y-3">
+          {kpi.alertes.map((alerte, index) => (
+            <div
+              key={index}
+              className={`rounded-lg p-4 border ${
+                alerte.type === 'error' 
+                  ? 'bg-red-50 border-red-200 text-red-800'
+                  : 'bg-yellow-50 border-yellow-200 text-yellow-800'
+              }`}
+            >
+              <div className="flex items-center">
+                <AlertTriangle className="h-5 w-5 mr-2" />
+                <div>
+                  <h4 className="font-medium">{alerte.message}</h4>
+                  {alerte.details && (
+                    <p className="text-sm mt-1 opacity-90">
+                      {alerte.details.join(', ')}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* KPI principaux */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-blue-600">Chantiers actifs</p>
+              <p className="text-3xl font-bold text-blue-700">{kpi.chantiersActifs}</p>
+            </div>
+            <MapPin className="h-8 w-8 text-blue-500" />
+          </div>
+          <div className="mt-2 text-xs text-blue-600">
+            {kpi.nombreChantiers} total • {kpi.chantiersTermines} terminés
+          </div>
+        </div>
+
+        <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-green-600">CA réalisé</p>
+              <p className="text-2xl font-bold text-green-700">
+                {formatEuro(kpi.caRealise)}
+              </p>
+            </div>
+            <TrendingUp className="h-8 w-8 text-green-500" />
+          </div>
+          <div className="mt-2 text-xs text-green-600">
+            Prévu: {formatEuro(kpi.caPrevu)}
+          </div>
+        </div>
+
+        <div className="bg-gradient-to-br from-purple-50 to-purple-100 rounded-lg p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-purple-600">Marge moyenne</p>
+              <p className={`text-3xl font-bold ${kpi.margeMoyenne >= 0 ? 'text-purple-700' : 'text-red-600'}`}>
+                {kpi.margeMoyenne.toFixed(1)}%
+              </p>
+            </div>
+            <BarChart3 className="h-8 w-8 text-purple-500" />
+          </div>
+          <div className="mt-2 text-xs text-purple-600">
+            Bénéfice: {formatEuro(kpi.beneficeEstime)}
+          </div>
+        </div>
+
+        <div className="bg-gradient-to-br from-orange-50 to-orange-100 rounded-lg p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-orange-600">Coût/heure</p>
+              <p className="text-2xl font-bold text-orange-700">
+                {formatEuro(kpi.coutMoyenHeure)}
+              </p>
+            </div>
+            <Clock className="h-8 w-8 text-orange-500" />
+          </div>
+          <div className="mt-2 text-xs text-orange-600">
+            {kpi.totalHeuresPrevues}h prévues
+          </div>
+        </div>
+      </div>
+
+      {/* Ressources */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold text-gray-800 flex items-center">
+              <Users className="h-5 w-5 text-blue-600 mr-2" />
+              Équipe ({kpi.nombreSalaries})
+            </h3>
+          </div>
+          
+          <div className="space-y-3">
+            {salaries.filter(s => s.actif).slice(0, 5).map((salarie) => (
+              <div key={salarie.id} className="flex items-center justify-between bg-gray-50 rounded-lg p-3">
+                <div>
+                  <div className="font-medium text-gray-900">
+                    {salarie.prenom} {salarie.nom}
+                  </div>
+                  <div className="text-sm text-gray-600 capitalize">
+                    {salarie.qualification.replace('_', ' ')}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="font-bold text-blue-600">{formatEuro(salarie.tauxHoraire)}/h</div>
+                  <div className="text-sm text-gray-600">{formatEuro(salarie.coutTotal)}/mois</div>
+                </div>
+              </div>
+            ))}
+            
+            {salaries.filter(s => s.actif).length > 5 && (
+              <div className="text-center text-sm text-gray-500">
+                +{salaries.filter(s => s.actif).length - 5} autres salariés
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold text-gray-800 flex items-center">
+              <Package className="h-5 w-5 text-orange-600 mr-2" />
+              Matériaux ({kpi.nombreMateriaux})
+            </h3>
+          </div>
+          
+          <div className="space-y-3">
+            {materiaux.filter(m => m.actif).slice(0, 5).map((materiau) => {
+              const stockFaible = materiau.seuilAlerte > 0 && materiau.quantiteStock <= materiau.seuilAlerte;
+              
+              return (
+                <div key={materiau.id} className="flex items-center justify-between bg-gray-50 rounded-lg p-3">
+                  <div className="flex items-center">
+                    {stockFaible ? (
+                      <AlertTriangle className="h-4 w-4 text-red-500 mr-2" />
+                    ) : (
+                      <CheckCircle className="h-4 w-4 text-green-500 mr-2" />
+                    )}
+                    <div>
+                      <div className="font-medium text-gray-900">{materiau.nom}</div>
+                      <div className="text-sm text-gray-600">
+                        Stock: {materiau.quantiteStock} {materiau.unite}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className="font-bold text-orange-600">
+                      {formatEuro(materiau.prixUnitaire)}
+                    </div>
+                    <div className="text-sm text-gray-600">/{materiau.unite}</div>
+                  </div>
+                </div>
+              );
+            })}
+            
+            {materiaux.filter(m => m.actif).length > 5 && (
+              <div className="text-center text-sm text-gray-500">
+                +{materiaux.filter(m => m.actif).length - 5} autres matériaux
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Chantiers récents */}
+      {chantiers.length > 0 && (
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
+            <MapPin className="h-5 w-5 text-green-600 mr-2" />
+            Chantiers récents
+          </h3>
+          
+          <div className="space-y-3">
+            {chantiers.slice(0, 5).map((chantier) => (
+              <div key={chantier.id} className="flex items-center justify-between bg-gray-50 rounded-lg p-4">
+                <div>
+                  <div className="font-medium text-gray-900">{chantier.nom}</div>
+                  <div className="text-sm text-gray-600">{chantier.client.nom}</div>
+                  <div className="text-xs text-gray-500">{chantier.reference}</div>
+                </div>
+                <div className="text-right">
+                  <div className="font-bold text-green-600">{formatEuro(chantier.coutTotal)}</div>
+                  {chantier.margeReelle !== undefined && (
+                    <div className={`text-sm ${chantier.margeReelle >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                      {chantier.margeReelle.toFixed(1)}% marge
+                    </div>
+                  )}
+                  <div className="text-xs text-gray-500 capitalize">
+                    {chantier.status.replace('_', ' ')}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Tendances */}
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">Tendances (30 derniers jours)</h3>
+        
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="bg-blue-50 rounded-lg p-4">
+            <div className="text-sm font-medium text-blue-600 mb-1">Nouveaux chantiers</div>
+            <div className="text-2xl font-bold text-blue-700">{kpi.tendances.nouveauxChantiers}</div>
+          </div>
+          
+          <div className="bg-green-50 rounded-lg p-4">
+            <div className="text-sm font-medium text-green-600 mb-1">Chantiers livrés</div>
+            <div className="text-2xl font-bold text-green-700">{kpi.tendances.chantiersLivres}</div>
+          </div>
+          
+          <div className="bg-purple-50 rounded-lg p-4">
+            <div className="text-sm font-medium text-purple-600 mb-1">Coût moyen chantier</div>
+            <div className="text-xl font-bold text-purple-700">
+              {formatEuro(kpi.coutMoyenChantier)}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/EstimerButton.tsx
+++ b/src/components/EstimerButton.tsx
@@ -1,0 +1,11 @@
+import { useState } from 'react';
+import { estimerChantier, type EstimationResponse, type PosteTravail } from '../domain/api';
+export default function EstimerButton({ postes, onDone, onError }:{ postes:PosteTravail[]; onDone:(r:EstimationResponse)=>void; onError:(m:string)=>void; }) {
+  const [loading, setLoading] = useState(false);
+  return <button disabled={loading} onClick={async()=>{
+    if (loading) return; setLoading(true);
+    try { const r=await estimerChantier({ postes }); onDone(r); }
+    catch(e:any){ onError(e?.message||'Erreur inconnue'); }
+    finally{ setLoading(false); }
+  }}>{loading?'Estimation…':'Estimer via API'}</button>;
+}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Building2, MapPin } from 'lucide-react';
+
+export const Header: React.FC = () => {
+  return (
+    <header className="bg-gradient-to-r from-blue-600 to-blue-700 text-white py-6 shadow-lg">
+      <div className="max-w-7xl mx-auto px-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <Building2 className="h-8 w-8" />
+            <div>
+              <h1 className="text-2xl font-bold">BTP Calculateur</h1>
+              <p className="text-blue-100 text-sm">Gestion des coûts chantier</p>
+            </div>
+          </div>
+          <div className="flex items-center text-blue-100">
+            <MapPin className="h-4 w-4 mr-1" />
+            <span className="text-sm">Montpellier, France</span>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/src/components/Materiaux/MateriauForm.tsx
+++ b/src/components/Materiaux/MateriauForm.tsx
@@ -1,0 +1,254 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Save, X, Package } from 'lucide-react';
+import { Materiau, MateriauFormData, MateriauFormSchema } from '../../schemas';
+
+interface MateriauFormProps {
+  materiau?: Materiau | null;
+  onSave: (materiau: Materiau) => void;
+  onCancel: () => void;
+}
+
+const CATEGORIES_MATERIAUX = [
+  { value: 'gros_oeuvre', label: 'Gros œuvre' },
+  { value: 'second_oeuvre', label: 'Second œuvre' },
+  { value: 'plomberie', label: 'Plomberie' },
+  { value: 'electricite', label: 'Électricité' },
+  { value: 'peinture', label: 'Peinture' },
+  { value: 'carrelage', label: 'Carrelage' },
+  { value: 'menuiserie', label: 'Menuiserie' },
+  { value: 'isolation', label: 'Isolation' },
+  { value: 'couverture', label: 'Couverture' },
+  { value: 'outillage', label: 'Outillage' },
+  { value: 'location_materiel', label: 'Location matériel' }
+];
+
+const UNITES = ['m²', 'm³', 'ml', 'kg', 't', 'sac', 'unité', 'lot', 'forfait'];
+
+export const MateriauForm: React.FC<MateriauFormProps> = ({ materiau, onSave, onCancel }) => {
+  const isEditing = !!materiau;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<MateriauFormData>({
+    resolver: zodResolver(MateriauFormSchema),
+    defaultValues: materiau ? {
+      nom: materiau.nom,
+      reference: materiau.reference,
+      prixUnitaire: materiau.prixUnitaire,
+      unite: materiau.unite,
+      quantiteStock: materiau.quantiteStock,
+      seuilAlerte: materiau.seuilAlerte,
+      fournisseur: materiau.fournisseur,
+      categorie: materiau.categorie,
+      tauxTVA: materiau.tauxTVA,
+      actif: materiau.actif,
+      tags: materiau.tags
+    } : {
+      unite: 'm²',
+      quantiteStock: 0,
+      seuilAlerte: 0,
+      categorie: 'gros_oeuvre',
+      tauxTVA: '20',
+      actif: true,
+      tags: []
+    }
+  });
+
+  const onSubmit = (data: MateriauFormData) => {
+    const materiauComplet: Materiau = {
+      id: materiau?.id || Date.now().toString(),
+      ...data
+    };
+
+    onSave(materiauComplet);
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center">
+          <Package className="h-5 w-5 text-orange-600 mr-2" />
+          <h3 className="text-lg font-semibold text-gray-800">
+            {isEditing ? 'Modifier le matériau' : 'Nouveau matériau'}
+          </h3>
+        </div>
+        <button
+          onClick={onCancel}
+          className="text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {/* Informations de base */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Nom du matériau *
+            </label>
+            <input
+              {...register('nom')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+              placeholder="Carrelage 60x60 blanc"
+            />
+            {errors.nom && (
+              <p className="text-red-600 text-sm mt-1">{errors.nom.message}</p>
+            )}
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Référence
+            </label>
+            <input
+              {...register('reference')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+              placeholder="REF-CAR-001"
+            />
+          </div>
+        </div>
+
+        {/* Prix et unité */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Prix unitaire HT (€) *
+            </label>
+            <input
+              {...register('prixUnitaire', { valueAsNumber: true })}
+              type="number"
+              step="0.01"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+              placeholder="25.50"
+            />
+            {errors.prixUnitaire && (
+              <p className="text-red-600 text-sm mt-1">{errors.prixUnitaire.message}</p>
+            )}
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Unité
+            </label>
+            <select
+              {...register('unite')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+            >
+              {UNITES.map((unite) => (
+                <option key={unite} value={unite}>{unite}</option>
+              ))}
+            </select>
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              TVA
+            </label>
+            <select
+              {...register('tauxTVA')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+            >
+              <option value="5.5">5,5% (rénovation)</option>
+              <option value="10">10% (amélioration)</option>
+              <option value="20">20% (standard)</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Gestion stock */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Quantité en stock
+            </label>
+            <input
+              {...register('quantiteStock', { valueAsNumber: true })}
+              type="number"
+              step="0.01"
+              min="0"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+              placeholder="0"
+            />
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Seuil d'alerte
+            </label>
+            <input
+              {...register('seuilAlerte', { valueAsNumber: true })}
+              type="number"
+              step="0.01"
+              min="0"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+              placeholder="10"
+            />
+          </div>
+        </div>
+
+        {/* Catégorie et fournisseur */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Catégorie
+            </label>
+            <select
+              {...register('categorie')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+            >
+              {CATEGORIES_MATERIAUX.map((cat) => (
+                <option key={cat.value} value={cat.value}>{cat.label}</option>
+              ))}
+            </select>
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Fournisseur
+            </label>
+            <input
+              {...register('fournisseur')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+              placeholder="Leroy Merlin, Point P..."
+            />
+          </div>
+        </div>
+
+        {/* Statut */}
+        <div className="flex items-center">
+          <label className="flex items-center">
+            <input
+              {...register('actif')}
+              type="checkbox"
+              className="rounded border-gray-300 text-orange-600 focus:ring-orange-500"
+            />
+            <span className="ml-2 text-sm text-gray-700">Matériau actif</span>
+          </label>
+        </div>
+
+        {/* Actions */}
+        <div className="flex space-x-4">
+          <button
+            type="submit"
+            className="flex-1 bg-orange-600 hover:bg-orange-700 text-white font-medium py-3 px-4 rounded-md transition-colors duration-200 flex items-center justify-center"
+          >
+            <Save className="h-5 w-5 mr-2" />
+            {isEditing ? 'Sauvegarder' : 'Ajouter le matériau'}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-6 bg-gray-300 hover:bg-gray-400 text-gray-700 font-medium py-3 rounded-md transition-colors duration-200"
+          >
+            Annuler
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/components/Materiaux/MateriauxList.tsx
+++ b/src/components/Materiaux/MateriauxList.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { Edit, Trash2, Package, AlertTriangle, CheckCircle } from 'lucide-react';
+import { Materiau } from '../../schemas';
+import { DataTable } from '../UI/DataTable';
+import { formatEuro } from '../../utils/calculsFiscaux';
+
+interface MateriauxListProps {
+  materiaux: Materiau[];
+  onEdit: (materiau: Materiau) => void;
+  onDelete: (id: string) => void;
+}
+
+export const MateriauxList: React.FC<MateriauxListProps> = ({ materiaux, onEdit, onDelete }) => {
+  const getCategoryLabel = (categorie: Materiau['categorie']) => {
+    const labels = {
+      'gros_oeuvre': 'Gros œuvre',
+      'second_oeuvre': 'Second œuvre',
+      'plomberie': 'Plomberie',
+      'electricite': 'Électricité',
+      'peinture': 'Peinture',
+      'carrelage': 'Carrelage',
+      'menuiserie': 'Menuiserie',
+      'isolation': 'Isolation',
+      'couverture': 'Couverture',
+      'outillage': 'Outillage',
+      'location_materiel': 'Location matériel'
+    };
+    return labels[categorie];
+  };
+
+  const getStockStatus = (materiau: Materiau) => {
+    if (materiau.seuilAlerte === 0) return null;
+    
+    if (materiau.quantiteStock <= materiau.seuilAlerte) {
+      return (
+        <div className="flex items-center text-red-600">
+          <AlertTriangle className="h-3 w-3 mr-1" />
+          <span className="text-xs">Stock faible</span>
+        </div>
+      );
+    }
+    
+    return (
+      <div className="flex items-center text-green-600">
+        <CheckCircle className="h-3 w-3 mr-1" />
+        <span className="text-xs">Stock OK</span>
+      </div>
+    );
+  };
+
+  const columns = [
+    {
+      key: 'nom',
+      header: 'Matériau',
+      sortable: true,
+      render: (materiau: Materiau) => (
+        <div className="flex items-center">
+          <Package className={`h-4 w-4 mr-2 ${materiau.actif ? 'text-green-500' : 'text-gray-400'}`} />
+          <div>
+            <div className="font-medium text-gray-900">{materiau.nom}</div>
+            {materiau.reference && (
+              <div className="text-sm text-gray-500">Réf: {materiau.reference}</div>
+            )}
+            <div className="text-xs text-gray-500">{getCategoryLabel(materiau.categorie)}</div>
+          </div>
+        </div>
+      )
+    },
+    {
+      key: 'prixUnitaire',
+      header: 'Prix unitaire',
+      sortable: true,
+      render: (materiau: Materiau) => (
+        <div className="text-right">
+          <div className="font-medium">{formatEuro(materiau.prixUnitaire)}</div>
+          <div className="text-sm text-gray-500">/{materiau.unite}</div>
+          <div className="text-xs text-gray-500">TVA {materiau.tauxTVA}%</div>
+        </div>
+      )
+    },
+    {
+      key: 'quantiteStock',
+      header: 'Stock',
+      sortable: true,
+      render: (materiau: Materiau) => (
+        <div className="text-center">
+          <div className="font-medium">{materiau.quantiteStock} {materiau.unite}</div>
+          {materiau.seuilAlerte > 0 && (
+            <div className="text-xs text-gray-500">Seuil: {materiau.seuilAlerte}</div>
+          )}
+          {getStockStatus(materiau)}
+        </div>
+      )
+    },
+    {
+      key: 'fournisseur',
+      header: 'Fournisseur',
+      sortable: true,
+      render: (materiau: Materiau) => (
+        <div className="text-sm text-gray-600">
+          {materiau.fournisseur || '-'}
+        </div>
+      )
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (materiau: Materiau) => (
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit(materiau);
+            }}
+            className="text-blue-600 hover:text-blue-800 transition-colors"
+            title="Modifier"
+          >
+            <Edit className="h-4 w-4" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(materiau.id);
+            }}
+            className="text-red-600 hover:text-red-800 transition-colors"
+            title="Supprimer"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      )
+    }
+  ];
+
+  return (
+    <DataTable
+      data={materiaux}
+      columns={columns}
+      searchPlaceholder="Rechercher par nom, référence, fournisseur..."
+      emptyMessage="Aucun matériau dans le catalogue"
+    />
+  );
+};

--- a/src/components/Materiaux/MateriauxManager.tsx
+++ b/src/components/Materiaux/MateriauxManager.tsx
@@ -1,0 +1,161 @@
+import React, { useState } from 'react';
+import { Plus, Download, RotateCcw, AlertTriangle } from 'lucide-react';
+import { Materiau } from '../../schemas';
+import { MateriauForm } from './MateriauForm';
+import { MateriauxList } from './MateriauxList';
+import { useToast } from '../UI/Toast';
+import { exportToCSV } from '../../services/importExportService';
+
+interface MateriauxManagerProps {
+  materiaux: Materiau[];
+  setMateriaux: (materiaux: Materiau[]) => boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const MateriauxManager: React.FC<MateriauxManagerProps> = ({
+  materiaux,
+  setMateriaux,
+  isLoading,
+  error
+}) => {
+  const [showForm, setShowForm] = useState(false);
+  const [editingMateriau, setEditingMateriau] = useState<Materiau | null>(null);
+  const { addToast } = useToast();
+
+  // Alertes stock
+  const stocksFaibles = materiaux.filter(m => 
+    m.actif && m.quantiteStock <= m.seuilAlerte && m.seuilAlerte > 0
+  );
+
+  const ajouterMateriau = (nouveauMateriau: Materiau) => {
+    const success = setMateriaux([...materiaux, nouveauMateriau]);
+    if (success) {
+      addToast({
+        type: 'success',
+        title: 'Matériau ajouté',
+        description: `${nouveauMateriau.nom} a été ajouté au catalogue`
+      });
+      setShowForm(false);
+    }
+  };
+
+  const modifierMateriau = (materiauModifie: Materiau) => {
+    const nouveauxMateriaux = materiaux.map(m => 
+      m.id === materiauModifie.id ? materiauModifie : m
+    );
+    const success = setMateriaux(nouveauxMateriaux);
+    
+    if (success) {
+      addToast({
+        type: 'success',
+        title: 'Matériau modifié',
+        description: `${materiauModifie.nom} a été mis à jour`
+      });
+      setEditingMateriau(null);
+    }
+  };
+
+  const supprimerMateriau = (id: string) => {
+    const materiau = materiaux.find(m => m.id === id);
+    if (!materiau) return;
+
+    if (window.confirm(`Êtes-vous sûr de vouloir supprimer "${materiau.nom}" ?`)) {
+      const success = setMateriaux(materiaux.filter(m => m.id !== id));
+      if (success) {
+        addToast({
+          type: 'success',
+          title: 'Matériau supprimé',
+          description: `${materiau.nom} a été supprimé`
+        });
+      }
+    }
+  };
+
+  const exporterMateriaux = () => {
+    const headers = ['nom', 'reference', 'prixUnitaire', 'unite', 'quantiteStock', 'seuilAlerte', 'fournisseur', 'categorie', 'tauxTVA'];
+    exportToCSV(materiaux, 'materiaux.csv', headers);
+    addToast({
+      type: 'success',
+      title: 'Export réussi',
+      description: 'Le catalogue matériaux a été exporté'
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-600"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+        <p className="text-red-800">Erreur: {error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Alertes stock */}
+      {stocksFaibles.length > 0 && (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <div className="flex items-center">
+            <AlertTriangle className="h-5 w-5 text-yellow-600 mr-2" />
+            <div>
+              <h4 className="font-medium text-yellow-800">Alertes stock</h4>
+              <p className="text-sm text-yellow-700">
+                {stocksFaibles.length} matériau(x) en stock faible: {stocksFaibles.map(m => m.nom).join(', ')}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Actions globales */}
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-800">Catalogue matériaux</h2>
+          <div className="flex items-center space-x-3">
+            <button
+              onClick={exporterMateriaux}
+              className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Download className="h-4 w-4 mr-2" />
+              Exporter CSV
+            </button>
+            <button
+              onClick={() => setShowForm(!showForm)}
+              className="bg-orange-600 hover:bg-orange-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Nouveau matériau
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Formulaire */}
+      {(showForm || editingMateriau) && (
+        <MateriauForm
+          materiau={editingMateriau}
+          onSave={editingMateriau ? modifierMateriau : ajouterMateriau}
+          onCancel={() => {
+            setShowForm(false);
+            setEditingMateriau(null);
+          }}
+        />
+      )}
+
+      {/* Liste */}
+      <MateriauxList
+        materiaux={materiaux}
+        onEdit={setEditingMateriau}
+        onDelete={supprimerMateriau}
+      />
+    </div>
+  );
+};

--- a/src/components/PostesForm.tsx
+++ b/src/components/PostesForm.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { PosteTravail } from '../domain/api';
+
+interface PostesFormProps {
+  value: PosteTravail[];
+  onChange: (value: PosteTravail[]) => void;
+}
+
+const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
+  const [newPoste, setNewPoste] = useState<{ nom: string; charge: string }>({
+    nom: '',
+    charge: ''
+  });
+  const [errors, setErrors] = useState<{ nom?: string; charge?: string }>({});
+
+  const validatePoste = (poste: { nom: string; charge: string }) => {
+    const newErrors: { nom?: string; charge?: string } = {};
+    let isValid = true;
+
+    if (!poste.nom.trim()) {
+      newErrors.nom = 'Le nom est requis';
+      isValid = false;
+    }
+
+    const chargeValue = parseFloat(poste.charge);
+    if (isNaN(chargeValue) || chargeValue < 0) {
+      newErrors.charge = 'La charge doit être un nombre positif';
+      isValid = false;
+    }
+
+    setErrors(newErrors);
+    return isValid;
+  };
+
+  const handleAddPoste = () => {
+    if (validatePoste(newPoste)) {
+      const newPosteItem: PosteTravail = {
+        id: crypto.randomUUID(),
+        nom: newPoste.nom.trim(),
+        charge: parseFloat(newPoste.charge)
+      };
+      
+      onChange([...value, newPosteItem]);
+      
+      // Réinitialiser le formulaire
+      setNewPoste({ nom: '', charge: '' });
+      setErrors({});
+    }
+  };
+
+  const handleDeletePoste = (id: string) => {
+    onChange(value.filter(poste => poste.id !== id));
+  };
+
+  const handleEditPoste = (id: string, field: 'nom' | 'charge', newValue: string) => {
+    const updatedPostes = value.map(poste => {
+      if (poste.id === id) {
+        if (field === 'nom') {
+          return { ...poste, nom: newValue };
+        } else if (field === 'charge') {
+          const chargeValue = parseFloat(newValue);
+          if (!isNaN(chargeValue) && chargeValue >= 0) {
+            return { ...poste, charge: chargeValue };
+          }
+        }
+      }
+      return poste;
+    });
+    
+    onChange(updatedPostes);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold">Postes de travail</h3>
+      
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="text-left p-2 border">Nom</th>
+            <th className="text-left p-2 border">Charge (h)</th>
+            <th className="text-left p-2 border">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {value.map(poste => (
+            <tr key={poste.id} className="border-b">
+              <td className="p-2 border">
+                <input
+                  type="text"
+                  value={poste.nom}
+                  onChange={(e) => handleEditPoste(poste.id, 'nom', e.target.value)}
+                  className="w-full p-1 border rounded"
+                />
+              </td>
+              <td className="p-2 border">
+                <input
+                  type="number"
+                  min="0"
+                  step="0.5"
+                  value={poste.charge}
+                  onChange={(e) => handleEditPoste(poste.id, 'charge', e.target.value)}
+                  className="w-full p-1 border rounded"
+                />
+              </td>
+              <td className="p-2 border">
+                <button
+                  onClick={() => handleDeletePoste(poste.id)}
+                  className="px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600"
+                >
+                  Supprimer
+                </button>
+              </td>
+            </tr>
+          ))}
+          
+          {/* Ligne pour ajouter un nouveau poste */}
+          <tr>
+            <td className="p-2 border">
+              <input
+                type="text"
+                value={newPoste.nom}
+                onChange={(e) => setNewPoste({ ...newPoste, nom: e.target.value })}
+                placeholder="Nom du poste"
+                className={`w-full p-1 border rounded ${errors.nom ? 'border-red-500' : ''}`}
+              />
+              {errors.nom && <p className="text-red-500 text-xs mt-1">{errors.nom}</p>}
+            </td>
+            <td className="p-2 border">
+              <input
+                type="number"
+                min="0"
+                step="0.5"
+                value={newPoste.charge}
+                onChange={(e) => setNewPoste({ ...newPoste, charge: e.target.value })}
+                placeholder="Heures"
+                className={`w-full p-1 border rounded ${errors.charge ? 'border-red-500' : ''}`}
+              />
+              {errors.charge && <p className="text-red-500 text-xs mt-1">{errors.charge}</p>}
+            </td>
+            <td className="p-2 border">
+              <button
+                onClick={handleAddPoste}
+                className="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600"
+              >
+                Ajouter
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      
+      {value.length === 0 && (
+        <p className="text-gray-500 italic">Aucun poste de travail défini</p>
+      )}
+    </div>
+  );
+};
+
+export default PostesForm;

--- a/src/components/Salaries/SalarieForm.tsx
+++ b/src/components/Salaries/SalarieForm.tsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Save, X, User } from 'lucide-react';
+import { Salarie, SalarieFormData, SalarieFormSchema } from '../../schemas';
+import { calculCompletSalaire, calculerTauxHoraire } from '../../utils/calculsFiscaux';
+
+interface SalarieFormProps {
+  salarie?: Salarie | null;
+  onSave: (salarie: Salarie) => void;
+  onCancel: () => void;
+}
+
+export const SalarieForm: React.FC<SalarieFormProps> = ({ salarie, onSave, onCancel }) => {
+  const isEditing = !!salarie;
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors }
+  } = useForm<SalarieFormData>({
+    resolver: zodResolver(SalarieFormSchema),
+    defaultValues: salarie ? {
+      nom: salarie.nom,
+      prenom: salarie.prenom,
+      salaireNet: salarie.salaireNet,
+      heuresParJour: salarie.heuresParJour,
+      qualification: salarie.qualification,
+      dateEmbauche: salarie.dateEmbauche,
+      actif: salarie.actif,
+      tags: salarie.tags
+    } : {
+      heuresParJour: 8,
+      qualification: 'ouvrier',
+      actif: true,
+      tags: []
+    }
+  });
+
+  const salaireNet = watch('salaireNet');
+  const calculs = React.useMemo(() => {
+    if (!salaireNet || salaireNet <= 0) return null;
+    return calculCompletSalaire(salaireNet);
+  }, [salaireNet]);
+
+  const onSubmit = (data: SalarieFormData) => {
+    if (!calculs) return;
+
+    const salarieComplet: Salarie = {
+      id: salarie?.id || Date.now().toString(),
+      ...data,
+      salaireBrut: calculs.salaireBrut,
+      chargesPatronales: calculs.chargesPatronales,
+      coutTotal: calculs.coutTotal,
+      tauxHoraire: calculerTauxHoraire(calculs.coutTotal)
+    };
+
+    onSave(salarieComplet);
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center">
+          <User className="h-5 w-5 text-blue-600 mr-2" />
+          <h3 className="text-lg font-semibold text-gray-800">
+            {isEditing ? 'Modifier le salarié' : 'Nouveau salarié'}
+          </h3>
+        </div>
+        <button
+          onClick={onCancel}
+          className="text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {/* Informations personnelles */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Nom *
+            </label>
+            <input
+              {...register('nom')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="Dupont"
+            />
+            {errors.nom && (
+              <p className="text-red-600 text-sm mt-1">{errors.nom.message}</p>
+            )}
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Prénom *
+            </label>
+            <input
+              {...register('prenom')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="Jean"
+            />
+            {errors.prenom && (
+              <p className="text-red-600 text-sm mt-1">{errors.prenom.message}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Informations professionnelles */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Qualification
+            </label>
+            <select
+              {...register('qualification')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value="ouvrier">Ouvrier</option>
+              <option value="chef_equipe">Chef d'équipe</option>
+              <option value="conducteur_travaux">Conducteur de travaux</option>
+              <option value="ingenieur">Ingénieur</option>
+            </select>
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Date d'embauche
+            </label>
+            <input
+              {...register('dateEmbauche')}
+              type="date"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Heures par jour
+            </label>
+            <input
+              {...register('heuresParJour', { valueAsNumber: true })}
+              type="number"
+              step="0.5"
+              min="1"
+              max="12"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+            {errors.heuresParJour && (
+              <p className="text-red-600 text-sm mt-1">{errors.heuresParJour.message}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Salaire */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Salaire net mensuel (€) *
+            </label>
+            <input
+              {...register('salaireNet', { valueAsNumber: true })}
+              type="number"
+              step="0.01"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="1800.00"
+            />
+            {errors.salaireNet && (
+              <p className="text-red-600 text-sm mt-1">{errors.salaireNet.message}</p>
+            )}
+          </div>
+          
+          <div className="flex items-center">
+            <label className="flex items-center">
+              <input
+                {...register('actif')}
+                type="checkbox"
+                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="ml-2 text-sm text-gray-700">Salarié actif</span>
+            </label>
+          </div>
+        </div>
+
+        {/* Calculs automatiques */}
+        {calculs && (
+          <div className="bg-blue-50 rounded-lg p-4">
+            <h4 className="font-medium text-blue-800 mb-3">Calculs automatiques (charges BTP)</h4>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm">
+              <div>
+                <span className="text-gray-600 block">Salaire brut:</span>
+                <span className="font-semibold text-blue-600">{calculs.salaireBrut.toFixed(2)} €</span>
+              </div>
+              <div>
+                <span className="text-gray-600 block">Charges patronales:</span>
+                <span className="font-semibold text-orange-600">{calculs.chargesPatronales.toFixed(2)} €</span>
+              </div>
+              <div>
+                <span className="text-gray-600 block">Coût total employeur:</span>
+                <span className="font-semibold text-green-600">{calculs.coutTotal.toFixed(2)} €</span>
+              </div>
+              <div>
+                <span className="text-gray-600 block">Taux horaire:</span>
+                <span className="font-semibold text-purple-600">
+                  {calculerTauxHoraire(calculs.coutTotal).toFixed(2)} €/h
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex space-x-4">
+          <button
+            type="submit"
+            disabled={!calculs}
+            className="flex-1 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 text-white font-medium py-3 px-4 rounded-md transition-colors duration-200 flex items-center justify-center"
+          >
+            <Save className="h-5 w-5 mr-2" />
+            {isEditing ? 'Sauvegarder' : 'Ajouter le salarié'}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-6 bg-gray-300 hover:bg-gray-400 text-gray-700 font-medium py-3 rounded-md transition-colors duration-200"
+          >
+            Annuler
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/components/Salaries/SalariesList.tsx
+++ b/src/components/Salaries/SalariesList.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { Edit, Trash2, User, UserCheck, UserX } from 'lucide-react';
+import { Salarie } from '../../schemas';
+import { DataTable } from '../UI/DataTable';
+import { formatEuro } from '../../utils/calculsFiscaux';
+
+interface SalariesListProps {
+  salaries: Salarie[];
+  onEdit: (salarie: Salarie) => void;
+  onDelete: (id: string) => void;
+}
+
+export const SalariesList: React.FC<SalariesListProps> = ({ salaries, onEdit, onDelete }) => {
+  const getQualificationBadge = (qualification: Salarie['qualification']) => {
+    const styles = {
+      'ouvrier': 'bg-blue-100 text-blue-800',
+      'chef_equipe': 'bg-purple-100 text-purple-800',
+      'conducteur_travaux': 'bg-green-100 text-green-800',
+      'ingenieur': 'bg-yellow-100 text-yellow-800'
+    };
+    
+    const labels = {
+      'ouvrier': 'Ouvrier',
+      'chef_equipe': 'Chef d\'équipe',
+      'conducteur_travaux': 'Conducteur',
+      'ingenieur': 'Ingénieur'
+    };
+
+    return (
+      <span className={`px-2 py-1 rounded-full text-xs font-medium ${styles[qualification]}`}>
+        {labels[qualification]}
+      </span>
+    );
+  };
+
+  const columns = [
+    {
+      key: 'nom',
+      header: 'Salarié',
+      sortable: true,
+      render: (salarie: Salarie) => (
+        <div className="flex items-center">
+          {salarie.actif ? (
+            <UserCheck className="h-4 w-4 text-green-500 mr-2" />
+          ) : (
+            <UserX className="h-4 w-4 text-red-500 mr-2" />
+          )}
+          <div>
+            <div className="font-medium text-gray-900">
+              {salarie.prenom} {salarie.nom}
+            </div>
+            <div className="text-sm text-gray-500">
+              {getQualificationBadge(salarie.qualification)}
+            </div>
+          </div>
+        </div>
+      )
+    },
+    {
+      key: 'salaireNet',
+      header: 'Net mensuel',
+      sortable: true,
+      render: (salarie: Salarie) => (
+        <div className="text-right">
+          <div className="font-medium">{formatEuro(salarie.salaireNet)}</div>
+          <div className="text-xs text-gray-500">{formatEuro(salarie.tauxHoraire)}/h</div>
+        </div>
+      )
+    },
+    {
+      key: 'salaireBrut',
+      header: 'Brut mensuel',
+      sortable: true,
+      render: (salarie: Salarie) => (
+        <div className="text-right font-medium">
+          {formatEuro(salarie.salaireBrut)}
+        </div>
+      )
+    },
+    {
+      key: 'chargesPatronales',
+      header: 'Charges patronales',
+      sortable: true,
+      render: (salarie: Salarie) => (
+        <div className="text-right">
+          <div className="font-medium text-orange-600">{formatEuro(salarie.chargesPatronales)}</div>
+          <div className="text-xs text-gray-500">44% BTP</div>
+        </div>
+      )
+    },
+    {
+      key: 'coutTotal',
+      header: 'Coût total',
+      sortable: true,
+      render: (salarie: Salarie) => (
+        <div className="text-right">
+          <div className="font-bold text-green-600 text-lg">{formatEuro(salarie.coutTotal)}</div>
+          <div className="text-xs text-gray-500">employeur</div>
+        </div>
+      )
+    },
+    {
+      key: 'dateEmbauche',
+      header: 'Embauche',
+      sortable: true,
+      render: (salarie: Salarie) => (
+        <div className="text-sm text-gray-600">
+          {salarie.dateEmbauche 
+            ? new Date(salarie.dateEmbauche).toLocaleDateString('fr-FR')
+            : '-'
+          }
+        </div>
+      )
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (salarie: Salarie) => (
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit(salarie);
+            }}
+            className="text-blue-600 hover:text-blue-800 transition-colors"
+            title="Modifier"
+          >
+            <Edit className="h-4 w-4" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(salarie.id);
+            }}
+            className="text-red-600 hover:text-red-800 transition-colors"
+            title="Supprimer"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      )
+    }
+  ];
+
+  return (
+    <DataTable
+      data={salaries}
+      columns={columns}
+      searchPlaceholder="Rechercher par nom, prénom, qualification..."
+      emptyMessage="Aucun salarié enregistré"
+    />
+  );
+};

--- a/src/components/Salaries/SalariesManager.tsx
+++ b/src/components/Salaries/SalariesManager.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import { Plus, Download, RotateCcw } from 'lucide-react';
+import { Salarie } from '../../schemas';
+import { SalarieForm } from './SalarieForm';
+import { SalariesList } from './SalariesList';
+import { useToast } from '../UI/Toast';
+import { exportToCSV } from '../../services/importExportService';
+
+interface SalariesManagerProps {
+  salaries: Salarie[];
+  setSalaries: (salaries: Salarie[]) => boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const SalariesManager: React.FC<SalariesManagerProps> = ({
+  salaries,
+  setSalaries,
+  isLoading,
+  error
+}) => {
+  const [showForm, setShowForm] = useState(false);
+  const [editingSalarie, setEditingSalarie] = useState<Salarie | null>(null);
+  const { addToast } = useToast();
+
+  const ajouterSalarie = (nouveauSalarie: Salarie) => {
+    const success = setSalaries([...salaries, nouveauSalarie]);
+    if (success) {
+      addToast({
+        type: 'success',
+        title: 'Salarié ajouté',
+        description: `${nouveauSalarie.prenom} ${nouveauSalarie.nom} a été ajouté`
+      });
+      setShowForm(false);
+    }
+  };
+
+  const modifierSalarie = (salarieModifie: Salarie) => {
+    const nouveauxSalaries = salaries.map(s => 
+      s.id === salarieModifie.id ? salarieModifie : s
+    );
+    const success = setSalaries(nouveauxSalaries);
+    
+    if (success) {
+      addToast({
+        type: 'success',
+        title: 'Salarié modifié',
+        description: `${salarieModifie.prenom} ${salarieModifie.nom} a été mis à jour`
+      });
+      setEditingSalarie(null);
+    }
+  };
+
+  const supprimerSalarie = (id: string) => {
+    const salarie = salaries.find(s => s.id === id);
+    if (!salarie) return;
+
+    if (window.confirm(`Êtes-vous sûr de vouloir supprimer ${salarie.prenom} ${salarie.nom} ?`)) {
+      const success = setSalaries(salaries.filter(s => s.id !== id));
+      if (success) {
+        addToast({
+          type: 'success',
+          title: 'Salarié supprimé',
+          description: `${salarie.prenom} ${salarie.nom} a été supprimé`
+        });
+      }
+    }
+  };
+
+  const exporterSalaries = () => {
+    const headers = ['nom', 'prenom', 'salaireNet', 'salaireBrut', 'chargesPatronales', 'coutTotal', 'tauxHoraire', 'qualification'];
+    exportToCSV(salaries, 'salaries.csv', headers);
+    addToast({
+      type: 'success',
+      title: 'Export réussi',
+      description: 'La liste des salariés a été exportée'
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+        <p className="text-red-800">Erreur: {error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Actions globales */}
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-800">Gestion des salariés</h2>
+          <div className="flex items-center space-x-3">
+            <button
+              onClick={exporterSalaries}
+              className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Download className="h-4 w-4 mr-2" />
+              Exporter CSV
+            </button>
+            <button
+              onClick={() => setShowForm(!showForm)}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Nouveau salarié
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Formulaire */}
+      {(showForm || editingSalarie) && (
+        <SalarieForm
+          salarie={editingSalarie}
+          onSave={editingSalarie ? modifierSalarie : ajouterSalarie}
+          onCancel={() => {
+            setShowForm(false);
+            setEditingSalarie(null);
+          }}
+        />
+      )}
+
+      {/* Liste */}
+      <SalariesList
+        salaries={salaries}
+        onEdit={setEditingSalarie}
+        onDelete={supprimerSalarie}
+      />
+    </div>
+  );
+};

--- a/src/components/Simulator/EstimationResultsCard.tsx
+++ b/src/components/Simulator/EstimationResultsCard.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { EstimationResponse, PosteTravail } from '../../domain/api';
+
+interface EstimationResultsCardProps {
+  estimation: EstimationResponse | null;
+  postes: PosteTravail[];
+}
+
+const formatCurrency = (amount: number) => {
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(amount);
+};
+
+const EstimationResultsCard: React.FC<EstimationResultsCardProps> = ({ estimation, postes }) => {
+  if (!estimation) return null;
+
+  // Créer un mapping des IDs de postes vers les noms
+  const posteNamesMap = postes.reduce((acc, poste) => {
+    acc[poste.id] = poste.nom;
+    return acc;
+  }, {} as Record<string, string>);
+
+  return (
+    <div className="mt-6 p-4 bg-white rounded-lg shadow">
+      <h3 className="text-lg font-semibold mb-4">Résultat API</h3>
+      
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="text-left p-2 border">Poste</th>
+              <th className="text-right p-2 border">Coût Matériaux</th>
+              <th className="text-right p-2 border">Coût Main d'Œuvre</th>
+              <th className="text-right p-2 border">Sous-total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {estimation.postes.map(poste => {
+              const sousTotal = poste.coutMateriaux + poste.coutMainOeuvre;
+              return (
+                <tr key={poste.id} className="border-b">
+                  <td className="p-2 border">{posteNamesMap[poste.id] || `Poste ${poste.id}`}</td>
+                  <td className="p-2 border text-right">{formatCurrency(poste.coutMateriaux)}</td>
+                  <td className="p-2 border text-right">{formatCurrency(poste.coutMainOeuvre)}</td>
+                  <td className="p-2 border text-right font-medium">{formatCurrency(sousTotal)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+          <tfoot className="bg-gray-50">
+            <tr>
+              <td colSpan={3} className="p-2 border text-right font-semibold">Total HT</td>
+              <td className="p-2 border text-right font-semibold">{formatCurrency(estimation.totalHT)}</td>
+            </tr>
+            <tr>
+              <td colSpan={3} className="p-2 border text-right font-semibold">Marge estimée</td>
+              <td className="p-2 border text-right font-semibold">{estimation.margeEstimee}%</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default EstimationResultsCard;

--- a/src/components/Simulator/Simulator.tsx
+++ b/src/components/Simulator/Simulator.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Salarie, Materiau, Chantier } from '../../types';
+import PostesForm from '../PostesForm';
+import EstimationResultsCard from './EstimationResultsCard';
+import { PosteTravail, EstimationResponse, estimerChantier } from '../../domain/api';
+
+interface SimulatorProps {
+  salaries: Salarie[];
+  materiaux: Materiau[];
+  chantiers: Chantier[];
+}
+
+export const Simulator: React.FC<SimulatorProps> = ({ salaries, materiaux, chantiers }) => {
+  const [postes, setPostes] = useState<PosteTravail[]>([]);
+  const [estimation, setEstimation] = useState<EstimationResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCalculer = async () => {
+    if (postes.length === 0) {
+      setError("Veuillez ajouter au moins un poste de travail");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await estimerChantier({ postes });
+      setEstimation(result);
+    } catch (err) {
+      setError(`Erreur lors de l'estimation: ${err instanceof Error ? err.message : 'Erreur inconnue'}`);
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white p-6 rounded-lg shadow">
+        <h2 className="text-xl font-bold mb-4">Simulateur de coûts</h2>
+        
+        <div className="mb-6">
+          <PostesForm value={postes} onChange={setPostes} />
+        </div>
+
+        <div className="mt-4">
+          <button
+            onClick={handleCalculer}
+            disabled={isLoading}
+            className={`px-4 py-2 rounded font-medium ${
+              isLoading ? 'bg-gray-400' : 'bg-blue-600 hover:bg-blue-700'
+            } text-white`}
+          >
+            {isLoading ? 'Calcul en cours...' : 'Calculer'}
+          </button>
+          
+          {error && (
+            <p className="mt-2 text-red-600">{error}</p>
+          )}
+        </div>
+
+        {/* Carte de résultats API */}
+        <EstimationResultsCard estimation={estimation} postes={postes} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/SousTraitants/SousTraitantForm.tsx
+++ b/src/components/SousTraitants/SousTraitantForm.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Save, X, Users } from 'lucide-react';
+import { SousTraitant, SousTraitantFormData, SousTraitantFormSchema } from '../../schemas';
+
+interface SousTraitantFormProps {
+  sousTraitant?: SousTraitant | null;
+  onSave: (sousTraitant: SousTraitant) => void;
+  onCancel: () => void;
+}
+
+const SPECIALITES = [
+  { value: 'plomberie', label: 'Plomberie' },
+  { value: 'electricite', label: 'Électricité' },
+  { value: 'peinture', label: 'Peinture' },
+  { value: 'carrelage', label: 'Carrelage' },
+  { value: 'menuiserie', label: 'Menuiserie' },
+  { value: 'isolation', label: 'Isolation' },
+  { value: 'couverture', label: 'Couverture' },
+  { value: 'cloisons', label: 'Cloisons' },
+  { value: 'sols', label: 'Sols' },
+  { value: 'facades', label: 'Façades' },
+  { value: 'autre', label: 'Autre' }
+];
+
+export const SousTraitantForm: React.FC<SousTraitantFormProps> = ({ sousTraitant, onSave, onCancel }) => {
+  const isEditing = !!sousTraitant;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<SousTraitantFormData>({
+    resolver: zodResolver(SousTraitantFormSchema),
+    defaultValues: sousTraitant ? {
+      nom: sousTraitant.nom,
+      entreprise: sousTraitant.entreprise,
+      specialite: sousTraitant.specialite,
+      tauxHoraire: sousTraitant.tauxHoraire,
+      telephone: sousTraitant.telephone,
+      email: sousTraitant.email,
+      adresse: sousTraitant.adresse,
+      siret: sousTraitant.siret,
+      actif: sousTraitant.actif,
+      notes: sousTraitant.notes,
+      tags: sousTraitant.tags
+    } : {
+      specialite: 'autre',
+      actif: true,
+      tags: []
+    }
+  });
+
+  const onSubmit = (data: SousTraitantFormData) => {
+    const sousTraitantComplet: SousTraitant = {
+      id: sousTraitant?.id || Date.now().toString(),
+      ...data
+    };
+
+    onSave(sousTraitantComplet);
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center">
+          <Users className="h-5 w-5 text-purple-600 mr-2" />
+          <h3 className="text-lg font-semibold text-gray-800">
+            {isEditing ? 'Modifier le sous-traitant' : 'Nouveau sous-traitant'}
+          </h3>
+        </div>
+        <button
+          onClick={onCancel}
+          className="text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {/* Informations de base */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Nom du contact *
+            </label>
+            <input
+              {...register('nom')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="Jean Dupont"
+            />
+            {errors.nom && (
+              <p className="text-red-600 text-sm mt-1">{errors.nom.message}</p>
+            )}
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Entreprise *
+            </label>
+            <input
+              {...register('entreprise')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="SARL Dupont Plomberie"
+            />
+            {errors.entreprise && (
+              <p className="text-red-600 text-sm mt-1">{errors.entreprise.message}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Spécialité */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Spécialité
+            </label>
+            <select
+              {...register('specialite')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+            >
+              {SPECIALITES.map((spec) => (
+                <option key={spec.value} value={spec.value}>{spec.label}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Contact */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Téléphone
+            </label>
+            <input
+              {...register('telephone')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="06 12 34 56 78"
+            />
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Email
+            </label>
+            <input
+              {...register('email')}
+              type="email"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="contact@entreprise.fr"
+            />
+            {errors.email && (
+              <p className="text-red-600 text-sm mt-1">{errors.email.message}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Adresse et SIRET */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Adresse
+            </label>
+            <input
+              {...register('adresse')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="123 rue de la Paix, Montpellier"
+            />
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              SIRET
+            </label>
+            <input
+              {...register('siret')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="12345678901234"
+            />
+          </div>
+        </div>
+
+        {/* Notes */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Notes
+          </label>
+          <textarea
+            {...register('notes')}
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+            placeholder="Notes sur le sous-traitant..."
+          />
+        </div>
+
+        {/* Statut */}
+        <div className="flex items-center">
+          <label className="flex items-center">
+            <input
+              {...register('actif')}
+              type="checkbox"
+              className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+            />
+            <span className="ml-2 text-sm text-gray-700">Sous-traitant actif</span>
+          </label>
+        </div>
+
+        {/* Actions */}
+        <div className="flex space-x-4">
+          <button
+            type="submit"
+            className="flex-1 bg-purple-600 hover:bg-purple-700 text-white font-medium py-3 px-4 rounded-md transition-colors duration-200 flex items-center justify-center"
+          >
+            <Save className="h-5 w-5 mr-2" />
+            {isEditing ? 'Sauvegarder' : 'Ajouter le sous-traitant'}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-6 bg-gray-300 hover:bg-gray-400 text-gray-700 font-medium py-3 rounded-md transition-colors duration-200"
+          >
+            Annuler
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/components/SousTraitants/SousTraitantsList.tsx
+++ b/src/components/SousTraitants/SousTraitantsList.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { Edit, Trash2, Users, Phone, Mail } from 'lucide-react';
+import { SousTraitant } from '../../schemas';
+import { DataTable } from '../UI/DataTable';
+import { formatEuro } from '../../utils/calculsFiscaux';
+
+interface SousTraitantsListProps {
+  sousTraitants: SousTraitant[];
+  onEdit: (sousTraitant: SousTraitant) => void;
+  onDelete: (id: string) => void;
+}
+
+export const SousTraitantsList: React.FC<SousTraitantsListProps> = ({ sousTraitants, onEdit, onDelete }) => {
+  const getSpecialiteLabel = (specialite: SousTraitant['specialite']) => {
+    const labels = {
+      'plomberie': 'Plomberie',
+      'electricite': 'Électricité',
+      'peinture': 'Peinture',
+      'carrelage': 'Carrelage',
+      'menuiserie': 'Menuiserie',
+      'isolation': 'Isolation',
+      'couverture': 'Couverture',
+      'cloisons': 'Cloisons',
+      'sols': 'Sols',
+      'facades': 'Façades',
+      'autre': 'Autre'
+    };
+    return labels[specialite];
+  };
+
+  const getSpecialiteBadge = (specialite: SousTraitant['specialite']) => {
+    const styles = {
+      'plomberie': 'bg-blue-100 text-blue-800',
+      'electricite': 'bg-yellow-100 text-yellow-800',
+      'peinture': 'bg-green-100 text-green-800',
+      'carrelage': 'bg-orange-100 text-orange-800',
+      'menuiserie': 'bg-brown-100 text-brown-800',
+      'isolation': 'bg-purple-100 text-purple-800',
+      'couverture': 'bg-red-100 text-red-800',
+      'cloisons': 'bg-gray-100 text-gray-800',
+      'sols': 'bg-indigo-100 text-indigo-800',
+      'facades': 'bg-pink-100 text-pink-800',
+      'autre': 'bg-gray-100 text-gray-800'
+    };
+
+    return (
+      <span className={`px-2 py-1 rounded-full text-xs font-medium ${styles[specialite]}`}>
+        {getSpecialiteLabel(specialite)}
+      </span>
+    );
+  };
+
+  const columns = [
+    {
+      key: 'nom',
+      header: 'Sous-traitant',
+      sortable: true,
+      render: (sousTraitant: SousTraitant) => (
+        <div className="flex items-center">
+          <Users className={`h-4 w-4 mr-2 ${sousTraitant.actif ? 'text-green-500' : 'text-gray-400'}`} />
+          <div>
+            <div className="font-medium text-gray-900">{sousTraitant.nom}</div>
+            <div className="text-sm text-gray-600">{sousTraitant.entreprise}</div>
+            <div className="mt-1">{getSpecialiteBadge(sousTraitant.specialite)}</div>
+          </div>
+        </div>
+      )
+    },
+    {
+      key: 'contact',
+      header: 'Contact',
+      render: (sousTraitant: SousTraitant) => (
+        <div className="text-sm">
+          {sousTraitant.telephone && (
+            <div className="flex items-center text-gray-600 mb-1">
+              <Phone className="h-3 w-3 mr-1" />
+              {sousTraitant.telephone}
+            </div>
+          )}
+          {sousTraitant.email && (
+            <div className="flex items-center text-gray-600">
+              <Mail className="h-3 w-3 mr-1" />
+              {sousTraitant.email}
+            </div>
+          )}
+        </div>
+      )
+    },
+    {
+      key: 'adresse',
+      header: 'Adresse',
+      render: (sousTraitant: SousTraitant) => (
+        <div className="text-sm text-gray-600">
+          {sousTraitant.adresse || '-'}
+        </div>
+      )
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (sousTraitant: SousTraitant) => (
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit(sousTraitant);
+            }}
+            className="text-blue-600 hover:text-blue-800 transition-colors"
+            title="Modifier"
+          >
+            <Edit className="h-4 w-4" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(sousTraitant.id);
+            }}
+            className="text-red-600 hover:text-red-800 transition-colors"
+            title="Supprimer"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      )
+    }
+  ];
+
+  return (
+    <DataTable
+      data={sousTraitants}
+      columns={columns}
+      searchPlaceholder="Rechercher par nom, entreprise, spécialité..."
+      emptyMessage="Aucun sous-traitant enregistré"
+    />
+  );
+};

--- a/src/components/SousTraitants/SousTraitantsManager.tsx
+++ b/src/components/SousTraitants/SousTraitantsManager.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import { Plus, Download, RotateCcw } from 'lucide-react';
+import { SousTraitant } from '../../schemas';
+import { SousTraitantForm } from './SousTraitantForm';
+import { SousTraitantsList } from './SousTraitantsList';
+import { useToast } from '../UI/Toast';
+import { exportToCSV } from '../../services/importExportService';
+
+interface SousTraitantsManagerProps {
+  sousTraitants: SousTraitant[];
+  setSousTraitants: (sousTraitants: SousTraitant[]) => boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const SousTraitantsManager: React.FC<SousTraitantsManagerProps> = ({
+  sousTraitants,
+  setSousTraitants,
+  isLoading,
+  error
+}) => {
+  const [showForm, setShowForm] = useState(false);
+  const [editingSousTraitant, setEditingSousTraitant] = useState<SousTraitant | null>(null);
+  const { addToast } = useToast();
+
+  const ajouterSousTraitant = (nouveauSousTraitant: SousTraitant) => {
+    const success = setSousTraitants([...sousTraitants, nouveauSousTraitant]);
+    if (success) {
+      addToast({
+        type: 'success',
+        title: 'Sous-traitant ajouté',
+        description: `${nouveauSousTraitant.entreprise} a été ajouté`
+      });
+      setShowForm(false);
+    }
+  };
+
+  const modifierSousTraitant = (sousTraitantModifie: SousTraitant) => {
+    const nouveauxSousTraitants = sousTraitants.map(st => 
+      st.id === sousTraitantModifie.id ? sousTraitantModifie : st
+    );
+    const success = setSousTraitants(nouveauxSousTraitants);
+    
+    if (success) {
+      addToast({
+        type: 'success',
+        title: 'Sous-traitant modifié',
+        description: `${sousTraitantModifie.entreprise} a été mis à jour`
+      });
+      setEditingSousTraitant(null);
+    }
+  };
+
+  const supprimerSousTraitant = (id: string) => {
+    const sousTraitant = sousTraitants.find(st => st.id === id);
+    if (!sousTraitant) return;
+
+    if (window.confirm(`Êtes-vous sûr de vouloir supprimer ${sousTraitant.entreprise} ?`)) {
+      const success = setSousTraitants(sousTraitants.filter(st => st.id !== id));
+      if (success) {
+        addToast({
+          type: 'success',
+          title: 'Sous-traitant supprimé',
+          description: `${sousTraitant.entreprise} a été supprimé`
+        });
+      }
+    }
+  };
+
+  const exporterSousTraitants = () => {
+    const headers = ['nom', 'entreprise', 'specialite', 'telephone', 'email', 'adresse'];
+    exportToCSV(sousTraitants, 'sous-traitants.csv', headers);
+    addToast({
+      type: 'success',
+      title: 'Export réussi',
+      description: 'La liste des sous-traitants a été exportée'
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+        <p className="text-red-800">Erreur: {error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Actions globales */}
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-800">Gestion des sous-traitants</h2>
+          <div className="flex items-center space-x-3">
+            <button
+              onClick={exporterSousTraitants}
+              className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Download className="h-4 w-4 mr-2" />
+              Exporter CSV
+            </button>
+            <button
+              onClick={() => setShowForm(!showForm)}
+              className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-md text-sm transition-colors flex items-center"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Nouveau sous-traitant
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Formulaire */}
+      {(showForm || editingSousTraitant) && (
+        <SousTraitantForm
+          sousTraitant={editingSousTraitant}
+          onSave={editingSousTraitant ? modifierSousTraitant : ajouterSousTraitant}
+          onCancel={() => {
+            setShowForm(false);
+            setEditingSousTraitant(null);
+          }}
+        />
+      )}
+
+      {/* Liste */}
+      <SousTraitantsList
+        sousTraitants={sousTraitants}
+        onEdit={setEditingSousTraitant}
+        onDelete={supprimerSousTraitant}
+      />
+    </div>
+  );
+};

--- a/src/components/UI/DataTable.tsx
+++ b/src/components/UI/DataTable.tsx
@@ -1,0 +1,182 @@
+import React, { useState, useMemo } from 'react';
+import { ChevronUp, ChevronDown, Search, Filter } from 'lucide-react';
+
+interface Column<T> {
+  key: keyof T | string;
+  header: string;
+  render?: (item: T) => React.ReactNode;
+  sortable?: boolean;
+  filterable?: boolean;
+  width?: string;
+}
+
+interface DataTableProps<T> {
+  data: T[];
+  columns: Column<T>[];
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  className?: string;
+  onRowClick?: (item: T) => void;
+}
+
+export function DataTable<T extends Record<string, any>>({
+  data,
+  columns,
+  searchable = true,
+  searchPlaceholder = 'Rechercher...',
+  emptyMessage = 'Aucune donnée',
+  className = '',
+  onRowClick
+}: DataTableProps<T>) {
+  const [sortConfig, setSortConfig] = useState<{
+    key: string;
+    direction: 'asc' | 'desc';
+  } | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filters, setFilters] = useState<Record<string, string>>({});
+
+  // Filtrage et tri
+  const processedData = useMemo(() => {
+    let filtered = data;
+
+    // Recherche globale
+    if (searchTerm) {
+      filtered = filtered.filter(item =>
+        Object.values(item).some(value =>
+          String(value).toLowerCase().includes(searchTerm.toLowerCase())
+        )
+      );
+    }
+
+    // Filtres par colonne
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value) {
+        filtered = filtered.filter(item =>
+          String(item[key]).toLowerCase().includes(value.toLowerCase())
+        );
+      }
+    });
+
+    // Tri
+    if (sortConfig) {
+      filtered.sort((a, b) => {
+        const aValue = a[sortConfig.key];
+        const bValue = b[sortConfig.key];
+        
+        if (aValue < bValue) {
+          return sortConfig.direction === 'asc' ? -1 : 1;
+        }
+        if (aValue > bValue) {
+          return sortConfig.direction === 'asc' ? 1 : -1;
+        }
+        return 0;
+      });
+    }
+
+    return filtered;
+  }, [data, searchTerm, filters, sortConfig]);
+
+  const handleSort = (key: string) => {
+    setSortConfig(current => {
+      if (current?.key === key) {
+        return current.direction === 'asc' 
+          ? { key, direction: 'desc' }
+          : null;
+      }
+      return { key, direction: 'asc' };
+    });
+  };
+
+  const getSortIcon = (key: string) => {
+    if (sortConfig?.key !== key) return null;
+    return sortConfig.direction === 'asc' 
+      ? <ChevronUp className="h-4 w-4" />
+      : <ChevronDown className="h-4 w-4" />;
+  };
+
+  if (data.length === 0) {
+    return (
+      <div className="bg-gray-50 rounded-lg p-8 text-center">
+        <p className="text-gray-500">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`bg-white rounded-lg shadow-md overflow-hidden ${className}`}>
+      {/* Barre de recherche et filtres */}
+      {searchable && (
+        <div className="p-4 border-b bg-gray-50">
+          <div className="flex items-center space-x-4">
+            <div className="flex-1 relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <input
+                type="text"
+                placeholder={searchPlaceholder}
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+            <Filter className="h-4 w-4 text-gray-400" />
+          </div>
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead className="bg-gray-50">
+            <tr>
+              {columns.map((column, index) => (
+                <th
+                  key={index}
+                  className={`px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider ${
+                    column.sortable ? 'cursor-pointer hover:bg-gray-100' : ''
+                  }`}
+                  style={{ width: column.width }}
+                  onClick={() => column.sortable && handleSort(column.key as string)}
+                >
+                  <div className="flex items-center space-x-1">
+                    <span>{column.header}</span>
+                    {column.sortable && getSortIcon(column.key as string)}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {processedData.map((item, rowIndex) => (
+              <tr
+                key={rowIndex}
+                className={`hover:bg-gray-50 transition-colors ${
+                  onRowClick ? 'cursor-pointer' : ''
+                }`}
+                onClick={() => onRowClick?.(item)}
+              >
+                {columns.map((column, colIndex) => (
+                  <td key={colIndex} className="px-6 py-4 whitespace-nowrap">
+                    {column.render 
+                      ? column.render(item)
+                      : String(item[column.key] || '-')
+                    }
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination (à implémenter si nécessaire) */}
+      <div className="px-6 py-3 bg-gray-50 border-t">
+        <div className="flex items-center justify-between">
+          <div className="text-sm text-gray-700">
+            Affichage de {processedData.length} sur {data.length} éléments
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UI/Tabs.tsx
+++ b/src/components/UI/Tabs.tsx
@@ -1,0 +1,125 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface TabsContextType {
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+}
+
+const TabsContext = createContext<TabsContextType | undefined>(undefined);
+
+interface TabsProps {
+  defaultValue: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Tabs: React.FC<TabsProps> = ({ 
+  defaultValue, 
+  value, 
+  onValueChange, 
+  children, 
+  className = '' 
+}) => {
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const activeTab = value ?? internalValue;
+  
+  const setActiveTab = (tab: string) => {
+    if (!value) setInternalValue(tab);
+    onValueChange?.(tab);
+  };
+
+  return (
+    <TabsContext.Provider value={{ activeTab, setActiveTab }}>
+      <div className={className}>
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+};
+
+interface TabsListProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const TabsList: React.FC<TabsListProps> = ({ children, className = '' }) => {
+  return (
+    <nav 
+      className={`bg-white rounded-lg shadow-sm p-1 ${className}`}
+      role="tablist"
+    >
+      <div className="flex space-x-1">
+        {children}
+      </div>
+    </nav>
+  );
+};
+
+interface TabsTriggerProps {
+  value: string;
+  children: React.ReactNode;
+  className?: string;
+  icon?: React.ReactNode;
+}
+
+export const TabsTrigger: React.FC<TabsTriggerProps> = ({ 
+  value, 
+  children, 
+  className = '', 
+  icon 
+}) => {
+  const context = useContext(TabsContext);
+  if (!context) throw new Error('TabsTrigger must be used within Tabs');
+  
+  const { activeTab, setActiveTab } = context;
+  const isActive = activeTab === value;
+
+  return (
+    <button
+      role="tab"
+      aria-selected={isActive}
+      aria-controls={`tabpanel-${value}`}
+      onClick={() => setActiveTab(value)}
+      className={`flex-1 px-4 py-3 text-sm font-medium rounded-md transition-all duration-200 ${
+        isActive
+          ? 'bg-blue-600 text-white shadow-sm'
+          : 'text-gray-600 hover:text-gray-800 hover:bg-gray-50'
+      } ${className}`}
+    >
+      {icon && <span className="mr-2">{icon}</span>}
+      {children}
+    </button>
+  );
+};
+
+interface TabsContentProps {
+  value: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const TabsContent: React.FC<TabsContentProps> = ({ 
+  value, 
+  children, 
+  className = '' 
+}) => {
+  const context = useContext(TabsContext);
+  if (!context) throw new Error('TabsContent must be used within Tabs');
+  
+  const { activeTab } = context;
+  
+  if (activeTab !== value) return null;
+
+  return (
+    <div
+      role="tabpanel"
+      id={`tabpanel-${value}`}
+      aria-labelledby={`tab-${value}`}
+      className={className}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/components/UI/Toast.tsx
+++ b/src/components/UI/Toast.tsx
@@ -1,0 +1,113 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import { X, CheckCircle, AlertCircle, Info, AlertTriangle } from 'lucide-react';
+
+interface Toast {
+  id: string;
+  type: 'success' | 'error' | 'warning' | 'info';
+  title: string;
+  description?: string;
+  duration?: number;
+}
+
+interface ToastContextType {
+  toasts: Toast[];
+  addToast: (toast: Omit<Toast, 'id'>) => void;
+  removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = Date.now().toString();
+    const newToast = { ...toast, id };
+    
+    setToasts(prev => [...prev, newToast]);
+    
+    // Auto-remove après duration
+    const duration = toast.duration ?? 5000;
+    if (duration > 0) {
+      setTimeout(() => {
+        removeToast(id);
+      }, duration);
+    }
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast, removeToast }}>
+      {children}
+      <ToastContainer />
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+  return context;
+};
+
+const ToastContainer: React.FC = () => {
+  const { toasts, removeToast } = useToast();
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed top-4 right-4 z-50 space-y-2">
+      {toasts.map(toast => (
+        <ToastItem key={toast.id} toast={toast} onRemove={removeToast} />
+      ))}
+    </div>
+  );
+};
+
+interface ToastItemProps {
+  toast: Toast;
+  onRemove: (id: string) => void;
+}
+
+const ToastItem: React.FC<ToastItemProps> = ({ toast, onRemove }) => {
+  const icons = {
+    success: CheckCircle,
+    error: AlertCircle,
+    warning: AlertTriangle,
+    info: Info
+  };
+
+  const styles = {
+    success: 'bg-green-50 border-green-200 text-green-800',
+    error: 'bg-red-50 border-red-200 text-red-800',
+    warning: 'bg-yellow-50 border-yellow-200 text-yellow-800',
+    info: 'bg-blue-50 border-blue-200 text-blue-800'
+  };
+
+  const Icon = icons[toast.type];
+
+  return (
+    <div className={`max-w-sm w-full border rounded-lg shadow-lg p-4 ${styles[toast.type]} animate-in slide-in-from-right duration-300`}>
+      <div className="flex items-start">
+        <Icon className="h-5 w-5 mt-0.5 mr-3 flex-shrink-0" />
+        <div className="flex-1">
+          <h4 className="font-medium">{toast.title}</h4>
+          {toast.description && (
+            <p className="text-sm mt-1 opacity-90">{toast.description}</p>
+          )}
+        </div>
+        <button
+          onClick={() => onRemove(toast.id)}
+          className="ml-3 flex-shrink-0 opacity-70 hover:opacity-100 transition-opacity"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/domain/api.ts
+++ b/src/domain/api.ts
@@ -1,0 +1,51 @@
+import { getConfig } from '@/lib/config';
+
+export type PosteTravail = { id: string; nom: string; charge: number }; // charge en heures
+export type EstimationRequest = { postes: PosteTravail[] };
+export type EstimationPoste = { id: string; coutMateriaux: number; coutMainOeuvre: number };
+export type EstimationResponse = { postes: EstimationPoste[]; totalHT: number; margeEstimee: number };
+
+export async function estimerChantier(data: EstimationRequest): Promise<EstimationResponse> {
+  const { apiBaseUrl } = await getConfig();
+  
+  // Mode mock si apiBaseUrl est null ou 'mock'
+  if (apiBaseUrl === null || apiBaseUrl === 'mock') {
+    // Simuler un délai réseau
+    await new Promise(r => setTimeout(r, 400));
+    
+    // Générer les données mock
+    const postes: EstimationPoste[] = data.postes.map(poste => {
+      const coutMateriaux = Math.round(poste.charge * 55);
+      const coutMainOeuvre = Math.round(poste.charge * 35);
+      
+      return {
+        id: poste.id,
+        coutMateriaux,
+        coutMainOeuvre
+      };
+    });
+    
+    // Calculer le total HT
+    const totalHT = postes.reduce((sum, poste) => 
+      sum + poste.coutMateriaux + poste.coutMainOeuvre, 0);
+    
+    // Calculer la marge estimée
+    const margeEstimee = Math.round(totalHT * 0.18);
+    
+    return {
+      postes,
+      totalHT,
+      margeEstimee
+    };
+  }
+  
+  // Mode production: appel API réel
+  const url = `${apiBaseUrl}/api/estimation`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(`API estimation ${res.status}`);
+  return res.json();
+}

--- a/src/hooks/useKPI.ts
+++ b/src/hooks/useKPI.ts
@@ -1,0 +1,110 @@
+import { useMemo } from 'react';
+import { Chantier, Salarie, Materiau } from '../schemas';
+
+export function useKPI(chantiers: Chantier[], salaries: Salarie[], materiaux: Materiau[]) {
+  return useMemo(() => {
+    const chantiersActifs = chantiers.filter(c => c.status !== 'prospect');
+    const chantiersTermines = chantiers.filter(c => c.status === 'livre' || c.status === 'facture' || c.status === 'paye');
+    
+    // Calculs financiers
+    const coutTotalChantiers = chantiersActifs.reduce((sum, c) => sum + c.coutTotal, 0);
+    const caRealise = chantiersTermines.reduce((sum, c) => sum + (c.prixVenteTTC || 0), 0);
+    const caPrevu = chantiers.reduce((sum, c) => sum + (c.prixVenteTTC || 0), 0);
+    
+    // Marges
+    const marges = chantiersTermines
+      .filter(c => c.margeReelle !== undefined)
+      .map(c => c.margeReelle!);
+    const margeMoyenne = marges.length > 0 ? marges.reduce((sum, m) => sum + m, 0) / marges.length : 0;
+    
+    // Productivité
+    const totalHeuresPrevues = chantiers.reduce((sum, c) => {
+      return sum + c.salaries.reduce((sSum, cs) => {
+        return sSum + cs.presences.reduce((pSum, p) => pSum + p.heuresPresence, 0);
+      }, 0);
+    }, 0);
+    
+    const coutMoyenHeure = totalHeuresPrevues > 0 ? coutTotalChantiers / totalHeuresPrevues : 0;
+    
+    // Alertes
+    const alertes = [];
+    
+    // Stock faible
+    const stocksFaibles = materiaux.filter(m => 
+      m.quantiteStock <= m.seuilAlerte && m.seuilAlerte > 0
+    );
+    if (stocksFaibles.length > 0) {
+      alertes.push({
+        type: 'warning' as const,
+        message: `${stocksFaibles.length} matériau(x) en stock faible`,
+        details: stocksFaibles.map(m => m.nom)
+      });
+    }
+    
+    // Chantiers en retard
+    const chantiersEnRetard = chantiers.filter(c => {
+      if (!c.dateFin || c.status === 'livre') return false;
+      return new Date(c.dateFin) < new Date();
+    });
+    if (chantiersEnRetard.length > 0) {
+      alertes.push({
+        type: 'error' as const,
+        message: `${chantiersEnRetard.length} chantier(s) en retard`,
+        details: chantiersEnRetard.map(c => c.nom)
+      });
+    }
+    
+    // Marges négatives
+    const chantiersMargeNegative = chantiersTermines.filter(c => 
+      c.margeReelle !== undefined && c.margeReelle < 0
+    );
+    if (chantiersMargeNegative.length > 0) {
+      alertes.push({
+        type: 'error' as const,
+        message: `${chantiersMargeNegative.length} chantier(s) avec marge négative`,
+        details: chantiersMargeNegative.map(c => c.nom)
+      });
+    }
+
+    return {
+      // Compteurs
+      nombreChantiers: chantiers.length,
+      chantiersActifs: chantiersActifs.length,
+      chantiersTermines: chantiersTermines.length,
+      nombreSalaries: salaries.filter(s => s.actif).length,
+      nombreMateriaux: materiaux.filter(m => m.actif).length,
+      
+      // Financier
+      coutTotalChantiers,
+      caRealise,
+      caPrevu,
+      margeMoyenne,
+      beneficeEstime: caRealise - chantiersTermines.reduce((sum, c) => sum + c.coutTotal, 0),
+      
+      // Productivité
+      totalHeuresPrevues,
+      coutMoyenHeure,
+      coutMoyenChantier: chantiersActifs.length > 0 ? coutTotalChantiers / chantiersActifs.length : 0,
+      
+      // Alertes
+      alertes,
+      
+      // Tendances (sur les 30 derniers jours)
+      tendances: {
+        nouveauxChantiers: chantiers.filter(c => {
+          const creation = new Date(c.dateCreation);
+          const il30Jours = new Date();
+          il30Jours.setDate(il30Jours.getDate() - 30);
+          return creation >= il30Jours;
+        }).length,
+        chantiersLivres: chantiersTermines.filter(c => {
+          if (!c.dateFin) return false;
+          const fin = new Date(c.dateFin);
+          const il30Jours = new Date();
+          il30Jours.setDate(il30Jours.getDate() - 30);
+          return fin >= il30Jours;
+        }).length
+      }
+    };
+  }, [chantiers, salaries, materiaux]);
+}

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,118 @@
+import { useState, useEffect, useCallback } from 'react';
+import { z } from 'zod';
+
+interface UseLocalStorageOptions<T> {
+  key: string;
+  schema: z.ZodSchema<T>;
+  defaultValue: T;
+  version?: number;
+}
+
+interface StorageData<T> {
+  data: T;
+  version: number;
+  timestamp: number;
+}
+
+export function useLocalStorage<T>({
+  key,
+  schema,
+  defaultValue,
+  version = 1
+}: UseLocalStorageOptions<T>) {
+  const [data, setData] = useState<T>(defaultValue);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Charger les données au montage
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      if (!stored) {
+        setData(defaultValue);
+        setIsLoading(false);
+        return;
+      }
+
+      const parsed = JSON.parse(stored) as StorageData<unknown>;
+      
+      // Vérifier la version
+      if (parsed.version !== version) {
+        console.warn(`Version mismatch for ${key}. Expected ${version}, got ${parsed.version}`);
+        // Ici on pourrait implémenter une migration
+        setData(defaultValue);
+        setIsLoading(false);
+        return;
+      }
+
+      // Valider avec Zod
+      const validated = schema.parse(parsed.data);
+      setData(validated);
+      setError(null);
+    } catch (err) {
+      console.error(`Error loading ${key}:`, err);
+      setError(err instanceof Error ? err.message : 'Erreur de chargement');
+      setData(defaultValue);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [key, schema, defaultValue, version]);
+
+  // Sauvegarder les données
+  const saveData = useCallback((newData: T) => {
+    try {
+      const validated = schema.parse(newData);
+      const toStore: StorageData<T> = {
+        data: validated,
+        version,
+        timestamp: Date.now()
+      };
+      
+      localStorage.setItem(key, JSON.stringify(toStore));
+      setData(validated);
+      setError(null);
+      return true;
+    } catch (err) {
+      console.error(`Error saving ${key}:`, err);
+      setError(err instanceof Error ? err.message : 'Erreur de sauvegarde');
+      return false;
+    }
+  }, [key, schema, version]);
+
+  // Réinitialiser
+  const reset = useCallback(() => {
+    localStorage.removeItem(key);
+    setData(defaultValue);
+    setError(null);
+  }, [key, defaultValue]);
+
+  // Export/Import
+  const exportData = useCallback(() => {
+    return {
+      key,
+      data,
+      version,
+      timestamp: Date.now()
+    };
+  }, [key, data, version]);
+
+  const importData = useCallback((importedData: any) => {
+    try {
+      const validated = schema.parse(importedData.data);
+      return saveData(validated);
+    } catch (err) {
+      setError('Données importées invalides');
+      return false;
+    }
+  }, [schema, saveData]);
+
+  return {
+    data,
+    setData: saveData,
+    isLoading,
+    error,
+    reset,
+    exportData,
+    importData
+  };
+}

--- a/src/hooks/useUndo.ts
+++ b/src/hooks/useUndo.ts
@@ -1,0 +1,65 @@
+import { useState, useCallback } from 'react';
+
+interface UseUndoOptions<T> {
+  maxHistory?: number;
+}
+
+export function useUndo<T>(initialState: T, options: UseUndoOptions<T> = {}) {
+  const { maxHistory = 10 } = options;
+  
+  const [history, setHistory] = useState<T[]>([initialState]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const currentState = history[currentIndex];
+  const canUndo = currentIndex > 0;
+  const canRedo = currentIndex < history.length - 1;
+
+  const setState = useCallback((newState: T | ((prev: T) => T)) => {
+    const state = typeof newState === 'function' 
+      ? (newState as (prev: T) => T)(currentState)
+      : newState;
+
+    setHistory(prev => {
+      const newHistory = prev.slice(0, currentIndex + 1);
+      newHistory.push(state);
+      
+      // Limiter l'historique
+      if (newHistory.length > maxHistory) {
+        newHistory.shift();
+        setCurrentIndex(maxHistory - 1);
+      } else {
+        setCurrentIndex(newHistory.length - 1);
+      }
+      
+      return newHistory;
+    });
+  }, [currentState, currentIndex, maxHistory]);
+
+  const undo = useCallback(() => {
+    if (canUndo) {
+      setCurrentIndex(prev => prev - 1);
+    }
+  }, [canUndo]);
+
+  const redo = useCallback(() => {
+    if (canRedo) {
+      setCurrentIndex(prev => prev + 1);
+    }
+  }, [canRedo]);
+
+  const reset = useCallback(() => {
+    setHistory([initialState]);
+    setCurrentIndex(0);
+  }, [initialState]);
+
+  return {
+    state: currentState,
+    setState,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    reset,
+    history: history.length
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,17 @@
+export type AppConfig = { apiBaseUrl: string | null };
+
+let cache: AppConfig | null = null;
+
+export async function getConfig(): Promise<AppConfig> {
+  if (cache) return cache;
+  
+  try {
+    const res = await fetch('/config.json', { cache: 'no-store' });
+    if (!res.ok) return (cache = { apiBaseUrl: null });
+    
+    const json = await res.json();
+    return (cache = { apiBaseUrl: json?.API_BASE_URL ?? null });
+  } catch {
+    return (cache = { apiBaseUrl: null });
+  }
+}

--- a/src/lib/id.ts
+++ b/src/lib/id.ts
@@ -1,0 +1,4 @@
+export function newId(): string {
+  // ID stable sans Web Crypto
+  return 'id_' + Math.floor(Date.now() * 1000 + Math.random() * 1000).toString(36);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+
+// Schémas de base
+export const SalarieSchema = z.object({
+  id: z.string(),
+  nom: z.string().min(1, 'Le nom est requis'),
+  prenom: z.string().min(1, 'Le prénom est requis'),
+  salaireNet: z.number().positive('Le salaire net doit être positif'),
+  salaireBrut: z.number().positive(),
+  chargesPatronales: z.number().positive(),
+  coutTotal: z.number().positive(),
+  tauxHoraire: z.number().positive(),
+  heuresParJour: z.number().min(1).max(12, 'Maximum 12h par jour'),
+  qualification: z.enum(['ouvrier', 'chef_equipe', 'conducteur_travaux', 'ingenieur']).default('ouvrier'),
+  dateEmbauche: z.string().optional(),
+  actif: z.boolean().default(true),
+  tags: z.array(z.string()).default([])
+});
+
+export const MateriauSchema = z.object({
+  id: z.string(),
+  nom: z.string().min(1, 'Le nom est requis'),
+  reference: z.string().optional(),
+  prixUnitaire: z.number().positive('Le prix doit être positif'),
+  unite: z.enum(['m²', 'm³', 'ml', 'kg', 't', 'sac', 'unité', 'lot', 'forfait']),
+  quantiteStock: z.number().min(0).default(0),
+  seuilAlerte: z.number().min(0).default(0),
+  fournisseur: z.string().optional(),
+  categorie: z.enum([
+    'gros_oeuvre', 'second_oeuvre', 'plomberie', 'electricite', 
+    'peinture', 'carrelage', 'menuiserie', 'isolation', 
+    'couverture', 'outillage', 'location_materiel'
+  ]),
+  tauxTVA: z.enum(['5.5', '10', '20']).default('20'),
+  actif: z.boolean().default(true),
+  tags: z.array(z.string()).default([])
+});
+
+export const ChantierPresenceSchema = z.object({
+  date: z.string(),
+  heuresPresence: z.number().min(0).max(24),
+  heuresSupplementaires: z.number().min(0).max(12).default(0),
+  tacheDescription: z.string().optional(),
+  commentaire: z.string().optional()
+});
+
+export const ChantierSalarieSchema = z.object({
+  salarieId: z.string(),
+  presences: z.array(ChantierPresenceSchema).default([]),
+  coutTotal: z.number().min(0).default(0)
+});
+
+export const ChantierMateriauSchema = z.object({
+  materiauId: z.string(),
+  quantite: z.number().positive(),
+  prixUnitaireReel: z.number().positive().optional(),
+  tauxTVA: z.enum(['5.5', '10', '20']).default('20'),
+  coutHT: z.number().min(0),
+  coutTTC: z.number().min(0)
+});
+
+export const EcheancierSchema = z.object({
+  id: z.string(),
+  libelle: z.string(),
+  montantHT: z.number().positive(),
+  montantTTC: z.number().positive(),
+  dateEcheance: z.string(),
+  statut: z.enum(['prevu', 'facture', 'paye']).default('prevu'),
+  numeroFacture: z.string().optional()
+});
+
+export const SousTraitantSchema = z.object({
+  id: z.string(),
+  nom: z.string().min(1, 'Le nom est requis'),
+  entreprise: z.string().min(1, 'Le nom de l\'entreprise est requis'),
+  specialite: z.enum([
+    'plomberie', 'electricite', 'peinture', 'carrelage', 'menuiserie', 
+    'isolation', 'couverture', 'cloisons', 'sols', 'facades', 'autre'
+  ]),
+  telephone: z.string().optional(),
+  email: z.string().email().optional(),
+  adresse: z.string().optional(),
+  siret: z.string().optional(),
+  actif: z.boolean().default(true),
+  notes: z.string().optional(),
+  tags: z.array(z.string()).default([])
+});
+
+export const ChantierSousTraitantSchema = z.object({
+  sousTraitantId: z.string(),
+  description: z.string().min(1, 'La description est requise'),
+  dateDebut: z.string(),
+  dateFin: z.string().optional(),
+  montantForfait: z.number().positive('Le montant forfaitaire doit être positif'),
+  coutTotal: z.number().min(0),
+  statut: z.enum(['prevu', 'en_cours', 'termine', 'facture']).default('prevu'),
+  notes: z.string().optional()
+});
+
+export const ChantierSchema = z.object({
+  id: z.string(),
+  reference: z.string().min(1, 'La référence est requise'),
+  nom: z.string().min(1, 'Le nom est requis'),
+  client: z.object({
+    nom: z.string().min(1),
+    adresse: z.string().min(1),
+    telephone: z.string().optional(),
+    email: z.string().email().optional(),
+    siret: z.string().optional()
+  }),
+  adresse: z.string().min(1, 'L\'adresse est requise'),
+  dateDebut: z.string(),
+  dateFin: z.string().optional(),
+  dateCreation: z.string(),
+  salaries: z.array(ChantierSalarieSchema).default([]),
+  materiaux: z.array(ChantierMateriauSchema).default([]),
+  sousTraitants: z.array(ChantierSousTraitantSchema).default([]),
+  fraisGeneraux: z.number().min(0).max(100).default(15),
+  margeObjectif: z.number().min(0).max(100).default(20),
+  coutMainOeuvre: z.number().min(0).default(0),
+  coutMateriaux: z.number().min(0).default(0),
+  coutSousTraitance: z.number().min(0).default(0),
+  coutTotal: z.number().min(0).default(0),
+  prixVenteHT: z.number().min(0).optional(),
+  prixVenteTTC: z.number().min(0).optional(),
+  margeReelle: z.number().optional(),
+  status: z.enum(['prospect', 'devis', 'en_cours', 'livre', 'facture', 'paye']).default('prospect'),
+  echeancier: z.array(EcheancierSchema).default([]),
+  tags: z.array(z.string()).default([]),
+  notes: z.string().optional(),
+  version: z.number().default(1)
+});
+
+// Types dérivés
+export type SousTraitant = z.infer<typeof SousTraitantSchema>;
+export type ChantierSousTraitant = z.infer<typeof ChantierSousTraitantSchema>;
+export type Salarie = z.infer<typeof SalarieSchema>;
+export type Materiau = z.infer<typeof MateriauSchema>;
+export type Chantier = z.infer<typeof ChantierSchema>;
+export type ChantierPresence = z.infer<typeof ChantierPresenceSchema>;
+export type ChantierSalarie = z.infer<typeof ChantierSalarieSchema>;
+export type ChantierMateriau = z.infer<typeof ChantierMateriauSchema>;
+export type Echeancier = z.infer<typeof EcheancierSchema>;
+
+// Schémas pour les formulaires
+export const SousTraitantFormSchema = SousTraitantSchema.omit({ id: true });
+export const SalarieFormSchema = SalarieSchema.omit({ 
+  id: true, 
+  salaireBrut: true, 
+  chargesPatronales: true, 
+  coutTotal: true, 
+  tauxHoraire: true 
+});
+
+export const MateriauFormSchema = MateriauSchema.omit({ id: true });
+
+export const ChantierFormSchema = ChantierSchema.omit({ 
+  id: true, 
+  dateCreation: true,
+  coutMainOeuvre: true,
+  coutMateriaux: true,
+  coutSousTraitance: true,
+  coutTotal: true,
+  margeReelle: true,
+  version: true
+});
+
+export type SousTraitantFormData = z.infer<typeof SousTraitantFormSchema>;
+export type SalarieFormData = z.infer<typeof SalarieFormSchema>;
+export type MateriauFormData = z.infer<typeof MateriauFormSchema>;
+export type ChantierFormData = z.infer<typeof ChantierFormSchema>;

--- a/src/services/costEngine.ts
+++ b/src/services/costEngine.ts
@@ -1,0 +1,283 @@
+import { Salarie, Materiau, Chantier, SousTraitant } from '../schemas';
+
+/**
+ * Moteur de calcul des coûts pour les chantiers BTP
+ * Calculs conformes à la réglementation française
+ */
+
+export interface CoutSalarie {
+  salaireNet: number;
+  salaireBrut: number;
+  chargesPatronales: number;
+  coutTotal: number;
+  tauxCharges: number;
+}
+
+export interface CoutMateriau {
+  prixHT: number;
+  montantTVA: number;
+  totalTTC: number;
+  tauxTVA: number;
+}
+
+export interface CoutChantier {
+  coutMainOeuvre: number;
+  coutMateriaux: number;
+  coutSousTraitance: number;
+  coutDirect: number;
+  fraisGeneraux: number;
+  coutTotal: number;
+  prixVenteRecommande: number;
+  margeReelle: number;
+  margeObjectif: number;
+}
+
+export interface KPIChantier {
+  nombreJoursTravailles: number;
+  heuresMoyennesParJour: number;
+  totalHeuresSupplementaires: number;
+  coutHoraireMoyen: number;
+  productivite: number; // heures réelles vs heures prévues
+  deriveMateriaux: number; // coût réel vs prévu
+  deriveSousTraitance: number; // coût réel vs prévu
+  rentabilite: number; // marge / CA
+}
+
+/**
+ * Calcule le coût complet d'un salarié (net → brut → charges → total employeur)
+ */
+export const calculerCoutSalarie = (
+  salaireNet: number,
+  nombreSemaines: number = 1,
+  heuresSupplementaires: number = 0
+): CoutSalarie => {
+  // Conversion net → brut (approximation pour le BTP)
+  const salaireBrut = salaireNet * 1.28;
+  
+  // Charges patronales BTP (taux moyen 44%)
+  const tauxCharges = 0.44;
+  const chargesPatronales = salaireBrut * tauxCharges;
+  
+  // Majoration heures supplémentaires (+25%)
+  const majorationHS = heuresSupplementaires * (salaireBrut / 35) * 0.25;
+  
+  const coutTotal = (salaireBrut + chargesPatronales + majorationHS) * nombreSemaines;
+
+  return {
+    salaireNet: salaireNet * nombreSemaines,
+    salaireBrut: salaireBrut * nombreSemaines,
+    chargesPatronales: (chargesPatronales + majorationHS) * nombreSemaines,
+    coutTotal,
+    tauxCharges
+  };
+};
+
+/**
+ * Calcule le coût d'un matériau avec TVA
+ */
+export const calculerCoutMateriau = (
+  prixUnitaire: number,
+  quantite: number,
+  tauxTVA: number = 20
+): CoutMateriau => {
+  const prixHT = prixUnitaire * quantite;
+  const montantTVA = prixHT * (tauxTVA / 100);
+  const totalTTC = prixHT + montantTVA;
+
+  return {
+    prixHT,
+    montantTVA,
+    totalTTC,
+    tauxTVA
+  };
+};
+
+/**
+ * Calcule le coût d'une prestation de sous-traitance
+ */
+export const calculerCoutSousTraitance = (montantForfait: number): number => {
+  return montantForfait;
+};
+
+/**
+ * Calcule le coût complet d'un chantier
+ */
+export const calculerCoutsChantier = (
+  chantier: Chantier,
+  salaries: Salarie[],
+  materiaux: Materiau[],
+  sousTraitants: SousTraitant[] = []
+) => {
+  // Calcul coût main d'œuvre
+  let coutMainOeuvre = 0;
+  
+  chantier.salaries.forEach(cs => {
+    coutMainOeuvre += cs.coutTotal;
+  });
+
+  // Calcul coût matériaux
+  let coutMateriaux = 0;
+  
+  chantier.materiaux.forEach(cm => {
+    coutMateriaux += cm.coutTTC;
+  });
+
+  // Calcul coût sous-traitance
+  let coutSousTraitance = 0;
+  
+  if (chantier.sousTraitants) {
+    chantier.sousTraitants.forEach(cst => {
+      coutSousTraitance += cst.coutTotal;
+    });
+  }
+
+  const coutDirect = coutMainOeuvre + coutMateriaux + coutSousTraitance;
+  const fraisGeneraux = coutDirect * (chantier.fraisGeneraux / 100);
+  const coutTotal = coutDirect + fraisGeneraux;
+  const prixVenteRecommande = coutTotal * (1 + chantier.margeObjectif / 100);
+  
+  const margeReelle = chantier.prixVenteTTC 
+    ? ((chantier.prixVenteTTC - coutTotal) / chantier.prixVenteTTC) * 100
+    : 0;
+
+  return {
+    coutMainOeuvre,
+    coutMateriaux,
+    coutSousTraitance,
+    coutDirect,
+    fraisGeneraux,
+    coutTotal,
+    prixVenteRecommande,
+    margeReelle,
+    margeObjectif: chantier.margeObjectif
+  };
+};
+
+/**
+ * Calcule les KPI d'un chantier
+ */
+export const calculerKPIChantier = (
+  chantier: Chantier,
+  salaries: Salarie[]
+): KPIChantier => {
+  let nombreJoursTravailles = 0;
+  let totalHeures = 0;
+  let totalHeuresSupplementaires = 0;
+  let coutTotal = 0;
+
+  // Analyse des présences
+  if (chantier.taches) {
+    chantier.taches.forEach(tache => {
+      const salarie = salaries.find(s => s.id === tache.salarieId);
+      if (salarie && tache.presences) {
+        nombreJoursTravailles += tache.presences.length;
+        
+        tache.presences.forEach(presence => {
+          totalHeures += presence.heuresNormales;
+          totalHeuresSupplementaires += presence.heuresSupplementaires || 0;
+          
+          const coutJour = calculerCoutSalarie(
+            salarie.salaireNet / 35 * presence.heuresNormales,
+            1,
+            presence.heuresSupplementaires || 0
+          );
+          coutTotal += coutJour.coutTotal;
+        });
+      }
+    });
+  }
+
+  const heuresMoyennesParJour = nombreJoursTravailles > 0 ? totalHeures / nombreJoursTravailles : 0;
+  const coutHoraireMoyen = totalHeures > 0 ? coutTotal / totalHeures : 0;
+  
+  // Calcul productivité (heures réelles vs prévues)
+  const heuresPrevues = chantier.taches?.reduce((acc, tache) => acc + tache.heures, 0) || 0;
+  const productivite = heuresPrevues > 0 ? (totalHeures / heuresPrevues) * 100 : 100;
+  
+  // Dérive matériaux (à implémenter avec budget prévisionnel)
+  const deriveMateriaux = 0;
+  
+  // Rentabilité
+  const rentabilite = chantier.prixVenteClient && chantier.prixVenteClient > 0
+    ? ((chantier.prixVenteClient - coutTotal) / chantier.prixVenteClient) * 100
+    : 0;
+
+  return {
+    nombreJoursTravailles,
+    heuresMoyennesParJour,
+    totalHeuresSupplementaires,
+    coutHoraireMoyen,
+    productivite,
+    deriveMateriaux,
+    rentabilite
+  };
+};
+
+/**
+ * Simule l'impact de variations sur un chantier
+ */
+export const simulerVariations = (
+  chantier: Chantier,
+  salaries: Salarie[],
+  materiaux: Materiau[],
+  variations: {
+    productivite: number; // %
+    prixMateriaux: number; // %
+    absences: number; // %
+  }
+): CoutChantier => {
+  // Créer une copie du chantier avec les variations appliquées
+  const chantierSimule: Chantier = {
+    ...chantier,
+    taches: chantier.taches?.map(tache => ({
+      ...tache,
+      heures: tache.heures * (1 + variations.absences / 100) / (1 + variations.productivite / 100)
+    })),
+    lignesMateriaux: chantier.lignesMateriaux?.map(ligne => {
+      const materiau = materiaux.find(m => m.id === ligne.materiauId);
+      if (materiau) {
+        const materiauAjuste: Materiau = {
+          ...materiau,
+          prixUnitaire: materiau.prixUnitaire * (1 + variations.prixMateriaux / 100)
+        };
+        return ligne;
+      }
+      return ligne;
+    })
+  };
+
+  return calculerCoutChantier(chantierSimule, salaries, materiaux);
+};
+
+/**
+ * Génère un rapport de coûts détaillé
+ */
+export const genererRapportCouts = (
+  chantier: Chantier,
+  salaries: Salarie[],
+  materiaux: Materiau[]
+) => {
+  const couts = calculerCoutChantier(chantier, salaries, materiaux);
+  const kpis = calculerKPIChantier(chantier, salaries);
+
+  return {
+    chantier: {
+      id: chantier.id,
+      nom: chantier.nom,
+      client: chantier.client,
+      statut: chantier.statut
+    },
+    couts,
+    kpis,
+    alertes: [
+      ...(couts.margeReelle < 10 ? ['Marge faible (< 10%)'] : []),
+      ...(kpis.productivite < 80 ? ['Productivité faible (< 80%)'] : []),
+      ...(kpis.totalHeuresSupplementaires > 20 ? ['Nombreuses heures supplémentaires'] : [])
+    ],
+    recommandations: [
+      ...(couts.margeReelle < 15 ? ['Revoir les prix de vente ou optimiser les coûts'] : []),
+      ...(kpis.heuresMoyennesParJour > 10 ? ['Surveiller la fatigue des équipes'] : []),
+      ...(kpis.productivite > 120 ? ['Excellente productivité, capitaliser sur les bonnes pratiques'] : [])
+    ]
+  };
+};

--- a/src/services/estimationAPI.ts
+++ b/src/services/estimationAPI.ts
@@ -1,0 +1,185 @@
+import axios from 'axios';
+import { Chantier } from '../schemas';
+
+// Types pour l'API d'estimation
+export interface PosteTravail {
+  id: string;
+  nom: string;
+  description: string;
+  unite: string;
+  quantite: number;
+}
+
+export interface EstimationPoste {
+  posteId: string;
+  materiaux: {
+    description: string;
+    quantite: number;
+    unite: string;
+    prixUnitaire: number;
+    coutTotal: number;
+  }[];
+  mainOeuvre: {
+    qualification: string;
+    heures: number;
+    tauxHoraire: number;
+    coutTotal: number;
+  }[];
+  coutMateriauxTotal: number;
+  coutMainOeuvreTotal: number;
+  coutTotal: number;
+}
+
+export interface EstimationChantier {
+  chantierRef: string;
+  postes: EstimationPoste[];
+  coutMateriauxTotal: number;
+  coutMainOeuvreTotal: number;
+  coutDirectTotal: number;
+  fraisGeneraux: number;
+  coutTotal: number;
+  margeRecommandee: number;
+  prixVenteRecommande: number;
+  commentaires: string[];
+}
+
+export interface EstimationRequest {
+  reference: string;
+  nom: string;
+  adresse: string;
+  surface: number;
+  typeConstruction: string;
+  postes: PosteTravail[];
+  commentaires?: string;
+  options?: {
+    qualite: 'standard' | 'premium' | 'luxe';
+    delai: 'normal' | 'urgent' | 'tres_urgent';
+    difficulte: 'facile' | 'moyen' | 'difficile';
+  };
+}
+
+// URL de l'API (à remplacer par l'URL réelle)
+const API_URL = process.env.ESTIMATION_API_URL || 'https://api.estimation-btp.com/v1';
+
+/**
+ * Obtient une estimation détaillée pour un chantier
+ */
+export const obtenirEstimation = async (request: EstimationRequest): Promise<EstimationChantier> => {
+  try {
+    // En environnement de développement, simuler une réponse
+    if (process.env.NODE_ENV === 'development') {
+      return simulerEstimation(request);
+    }
+    
+    // En production, appeler l'API réelle
+    const response = await axios.post(`${API_URL}/estimations`, request);
+    return response.data;
+  } catch (error) {
+    console.error('Erreur lors de l\'estimation du chantier:', error);
+    throw new Error('Impossible d\'obtenir l\'estimation. Veuillez réessayer plus tard.');
+  }
+};
+
+/**
+ * Convertit une estimation en chantier
+ */
+export const convertirEstimationEnChantier = (estimation: EstimationChantier): Partial<Chantier> => {
+  // Conversion des données d'estimation en structure de chantier
+  return {
+    reference: estimation.chantierRef,
+    nom: `Chantier basé sur estimation ${estimation.chantierRef}`,
+    fraisGeneraux: estimation.fraisGeneraux,
+    margeObjectif: estimation.margeRecommandee,
+    prixVenteHT: estimation.prixVenteRecommande,
+    prixVenteTTC: estimation.prixVenteRecommande * 1.2, // Approximation TVA 20%
+    notes: `Estimation générée automatiquement.\n\nCommentaires: ${estimation.commentaires.join('\n')}`
+  };
+};
+
+/**
+ * Fonction de simulation pour le développement
+ * À remplacer par l'appel API réel en production
+ */
+const simulerEstimation = (request: EstimationRequest): EstimationChantier => {
+  // Calcul des coûts de base en fonction de la surface
+  const coutMateriauxBase = request.surface * 250; // 250€/m² pour les matériaux
+  const coutMainOeuvreBase = request.surface * 200; // 200€/m² pour la main d'œuvre
+  
+  // Ajustements en fonction des options
+  const coeffQualite = request.options?.qualite === 'premium' ? 1.3 : 
+                       request.options?.qualite === 'luxe' ? 1.8 : 1;
+  
+  const coeffDelai = request.options?.delai === 'urgent' ? 1.2 : 
+                     request.options?.delai === 'tres_urgent' ? 1.4 : 1;
+  
+  const coeffDifficulte = request.options?.difficulte === 'moyen' ? 1.15 : 
+                          request.options?.difficulte === 'difficile' ? 1.3 : 1;
+  
+  // Application des coefficients
+  const coutMateriauxTotal = coutMateriauxBase * coeffQualite * coeffDifficulte;
+  const coutMainOeuvreTotal = coutMainOeuvreBase * coeffDelai * coeffDifficulte;
+  
+  // Création des postes d'estimation
+  const postes: EstimationPoste[] = request.postes.map(poste => {
+    // Répartition des coûts par poste (simulation)
+    const ratio = poste.quantite / request.postes.reduce((sum, p) => sum + p.quantite, 0);
+    const coutMateriauxPoste = coutMateriauxTotal * ratio;
+    const coutMainOeuvrePoste = coutMainOeuvreTotal * ratio;
+    
+    return {
+      posteId: poste.id,
+      materiaux: [
+        {
+          description: `Matériaux pour ${poste.nom}`,
+          quantite: poste.quantite,
+          unite: poste.unite,
+          prixUnitaire: coutMateriauxPoste / poste.quantite,
+          coutTotal: coutMateriauxPoste
+        }
+      ],
+      mainOeuvre: [
+        {
+          qualification: 'ouvrier',
+          heures: coutMainOeuvrePoste / 35, // Approximation à 35€/h
+          tauxHoraire: 35,
+          coutTotal: coutMainOeuvrePoste
+        }
+      ],
+      coutMateriauxTotal: coutMateriauxPoste,
+      coutMainOeuvreTotal: coutMainOeuvrePoste,
+      coutTotal: coutMateriauxPoste + coutMainOeuvrePoste
+    };
+  });
+  
+  // Calcul des totaux
+  const coutDirectTotal = coutMateriauxTotal + coutMainOeuvreTotal;
+  const fraisGeneraux = coutDirectTotal * 0.15; // 15% de frais généraux
+  const coutTotal = coutDirectTotal + fraisGeneraux;
+  const margeRecommandee = 20; // 20% de marge recommandée
+  const prixVenteRecommande = coutTotal * (1 + margeRecommandee / 100);
+  
+  // Génération de commentaires pertinents
+  const commentaires = [
+    `Estimation basée sur une surface de ${request.surface}m² pour un projet de type ${request.typeConstruction}.`,
+    `Qualité des matériaux: ${request.options?.qualite || 'standard'}.`,
+    `Délai d'exécution: ${request.options?.delai || 'normal'}.`,
+    `Niveau de difficulté estimé: ${request.options?.difficulte || 'facile'}.`
+  ];
+  
+  if (request.commentaires) {
+    commentaires.push(`Commentaires client: ${request.commentaires}`);
+  }
+  
+  return {
+    chantierRef: request.reference,
+    postes,
+    coutMateriauxTotal,
+    coutMainOeuvreTotal,
+    coutDirectTotal,
+    fraisGeneraux,
+    coutTotal,
+    margeRecommandee,
+    prixVenteRecommande,
+    commentaires
+  };
+};

--- a/src/services/importExportService.ts
+++ b/src/services/importExportService.ts
@@ -1,0 +1,109 @@
+import { Salarie, Materiau, Chantier } from '../schemas';
+
+export const exportToJSON = (data: {
+  salaries: Salarie[];
+  materiaux: Materiau[];
+  chantiers: Chantier[];
+}) => {
+  const exportData = {
+    ...data,
+    exportDate: new Date().toISOString(),
+    version: '1.0'
+  };
+  
+  const blob = new Blob([JSON.stringify(exportData, null, 2)], { 
+    type: 'application/json' 
+  });
+  
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `btp-backup-${new Date().toISOString().split('T')[0]}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+export const exportToCSV = (data: any[], filename: string, headers: string[]) => {
+  const csvContent = [
+    headers.join(','),
+    ...data.map(row => headers.map(header => {
+      const value = row[header] || '';
+      return typeof value === 'string' && value.includes(',') 
+        ? `"${value}"` 
+        : value;
+    }).join(','))
+  ].join('\n');
+  
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+export const importFromJSON = (file: File): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const data = JSON.parse(e.target?.result as string);
+        resolve(data);
+      } catch (error) {
+        reject(new Error('Fichier JSON invalide'));
+      }
+    };
+    reader.onerror = () => reject(new Error('Erreur de lecture du fichier'));
+    reader.readAsText(file);
+  });
+};
+
+export const parseCSV = (csvText: string): string[][] => {
+  const lines = csvText.split('\n');
+  const result: string[][] = [];
+  
+  for (const line of lines) {
+    if (line.trim()) {
+      const row: string[] = [];
+      let current = '';
+      let inQuotes = false;
+      
+      for (let i = 0; i < line.length; i++) {
+        const char = line[i];
+        
+        if (char === '"') {
+          inQuotes = !inQuotes;
+        } else if (char === ',' && !inQuotes) {
+          row.push(current.trim());
+          current = '';
+        } else {
+          current += char;
+        }
+      }
+      
+      row.push(current.trim());
+      result.push(row);
+    }
+  }
+  
+  return result;
+};
+
+export const genererNumeroDevis = (chantiers: Chantier[]): string => {
+  const annee = new Date().getFullYear();
+  const devisAnnee = chantiers.filter(c => 
+    c.dateCreation.startsWith(annee.toString())
+  ).length + 1;
+  
+  return `DEV${annee}${devisAnnee.toString().padStart(4, '0')}`;
+};
+
+export const genererNumeroFacture = (chantiers: Chantier[]): string => {
+  const annee = new Date().getFullYear();
+  const facturesAnnee = chantiers.filter(c => 
+    c.status === 'facture' || c.status === 'paye'
+  ).length + 1;
+  
+  return `FAC${annee}${facturesAnnee.toString().padStart(4, '0')}`;
+};

--- a/src/services/localStorage.ts
+++ b/src/services/localStorage.ts
@@ -1,0 +1,87 @@
+import { Salarie, Materiau, Chantier } from '../types';
+
+const STORAGE_KEYS = {
+  SALARIES: 'btp-calculator-salaries',
+  MATERIAUX: 'btp-calculator-materiaux', 
+  CHANTIERS: 'btp-calculator-chantiers'
+};
+
+export const saveSalaries = (salaries: Salarie[]): void => {
+  localStorage.setItem(STORAGE_KEYS.SALARIES, JSON.stringify(salaries));
+};
+
+export const loadSalaries = (): Salarie[] => {
+  const data = localStorage.getItem(STORAGE_KEYS.SALARIES);
+  return data ? JSON.parse(data) : [];
+};
+
+export const saveMateriaux = (materiaux: Materiau[]): void => {
+  localStorage.setItem(STORAGE_KEYS.MATERIAUX, JSON.stringify(materiaux));
+};
+
+export const loadMateriaux = (): Materiau[] => {
+  const data = localStorage.getItem(STORAGE_KEYS.MATERIAUX);
+  return data ? JSON.parse(data) : [];
+};
+
+export const saveChantiers = (chantiers: Chantier[]): void => {
+  localStorage.setItem(STORAGE_KEYS.CHANTIERS, JSON.stringify(chantiers));
+};
+
+export const loadChantiers = (): Chantier[] => {
+  const data = localStorage.getItem(STORAGE_KEYS.CHANTIERS);
+  return data ? JSON.parse(data) : [];
+};
+
+export const exportToPDF = (chantier: Chantier): void => {
+  // Pour une vraie implémentation, nous utiliserions une lib comme jsPDF
+  // Ici, nous créons un récapitulatif formaté pour impression
+  
+  // Calcul des détails de présence
+  const detailsPresences = chantier.salaries.map(cs => {
+    const totalHeures = cs.presences.reduce((sum, p) => sum + p.heuresPresence, 0);
+    const totalHeuresSupp = cs.presences.reduce((sum, p) => sum + (p.heuresSupplementaires || 0), 0);
+    const nombreJours = cs.presences.length;
+    return {
+      salarieId: cs.salarieId,
+      nombreJours,
+      totalHeures,
+      totalHeuresSupp,
+      coutTotal: cs.coutTotal,
+      presences: cs.presences
+    };
+  }).filter(d => d.nombreJours > 0);
+
+  const content = `
+=== RÉCAPITULATIF CHANTIER ===
+Nom: ${chantier.nom}
+Adresse: ${chantier.adresse}
+Période: ${chantier.dateDebut} - ${chantier.dateFin}
+
+DÉTAIL MAIN D'ŒUVRE:
+${detailsPresences.map(detail => `
+Salarié ID: ${detail.salarieId}
+- ${detail.nombreJours} jours travaillés
+- ${detail.totalHeures}h normales${detail.totalHeuresSupp > 0 ? ` + ${detail.totalHeuresSupp}h supplémentaires` : ''}
+- Coût: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(detail.coutTotal)}
+
+Détail des présences:
+${detail.presences.map(p => `  ${p.date}: ${p.heuresPresence}h${p.heuresSupplementaires ? ` +${p.heuresSupplementaires}h supp.` : ''}${p.commentaire ? ` (${p.commentaire})` : ''}`).join('\n')}
+`).join('\n')}
+
+Main d'œuvre: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(chantier.coutMainOeuvre)}
+Matériaux: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(chantier.coutMateriaux)}
+Frais généraux: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format((chantier.coutMainOeuvre + chantier.coutMateriaux) * (chantier.fraisGeneraux / 100))}
+
+COÛT TOTAL: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(chantier.coutTotal)}
+${chantier.marge ? `MARGE: ${new Intl.NumberFormat('fr-FR', { style: 'percent', maximumFractionDigits: 1 }).format(chantier.marge / 100)}` : ''}
+  `.trim();
+
+  const blob = new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `chantier-${chantier.nom.replace(/\s+/g, '-').toLowerCase()}.txt`;
+  a.click();
+  URL.revokeObjectURL(url);
+};

--- a/src/services/pdfService.ts
+++ b/src/services/pdfService.ts
@@ -1,0 +1,262 @@
+import jsPDF from 'jspdf';
+import { Chantier, Salarie, Materiau, SousTraitant } from '../schemas';
+import { calculerCoutsChantier } from './costEngine';
+import { formatEuro, calculerTVA } from '../utils/calculsFiscaux';
+
+export const genererDevisPDF = (
+  chantier: Chantier,
+  salaries: Salarie[],
+  materiaux: Materiau[],
+  sousTraitants: SousTraitant[],
+  numeroDevis: string
+) => {
+  const pdf = new jsPDF();
+  const pageWidth = pdf.internal.pageSize.width;
+  const margin = 20;
+  let yPosition = margin;
+
+  // En-tête entreprise
+  pdf.setFontSize(20);
+  pdf.setFont('helvetica', 'bold');
+  pdf.text('BTP SARL MONTPELLIER', margin, yPosition);
+  yPosition += 10;
+  
+  pdf.setFontSize(10);
+  pdf.setFont('helvetica', 'normal');
+  pdf.text('123 Avenue de la République, 34000 Montpellier', margin, yPosition);
+  yPosition += 5;
+  pdf.text('Tél: 04 67 XX XX XX - Email: contact@btp-montpellier.fr', margin, yPosition);
+  yPosition += 5;
+  pdf.text('SIRET: 123 456 789 00012 - TVA: FR12345678901', margin, yPosition);
+  yPosition += 20;
+
+  // Titre devis
+  pdf.setFontSize(16);
+  pdf.setFont('helvetica', 'bold');
+  pdf.text(`DEVIS N° ${numeroDevis}`, pageWidth - margin - 60, margin + 20);
+  yPosition += 10;
+
+  // Informations client
+  pdf.setFontSize(12);
+  pdf.setFont('helvetica', 'bold');
+  pdf.text('CLIENT:', margin, yPosition);
+  yPosition += 8;
+  
+  pdf.setFont('helvetica', 'normal');
+  pdf.text(chantier.client.nom, margin, yPosition);
+  yPosition += 6;
+  pdf.text(chantier.client.adresse, margin, yPosition);
+  yPosition += 6;
+  if (chantier.client.telephone) {
+    pdf.text(`Tél: ${chantier.client.telephone}`, margin, yPosition);
+    yPosition += 6;
+  }
+  if (chantier.client.email) {
+    pdf.text(`Email: ${chantier.client.email}`, margin, yPosition);
+    yPosition += 6;
+  }
+  yPosition += 10;
+
+  // Informations chantier
+  pdf.setFont('helvetica', 'bold');
+  pdf.text('CHANTIER:', margin, yPosition);
+  yPosition += 8;
+  
+  pdf.setFont('helvetica', 'normal');
+  pdf.text(`Nom: ${chantier.nom}`, margin, yPosition);
+  yPosition += 6;
+  pdf.text(`Adresse: ${chantier.adresse}`, margin, yPosition);
+  yPosition += 6;
+  pdf.text(`Période: ${new Date(chantier.dateDebut).toLocaleDateString('fr-FR')}${chantier.dateFin ? ` - ${new Date(chantier.dateFin).toLocaleDateString('fr-FR')}` : ''}`, margin, yPosition);
+  yPosition += 15;
+
+  // Calculs
+  const couts = calculerCoutsChantier(chantier, salaries, materiaux, sousTraitants);
+  
+  // Tableau des coûts
+  pdf.setFont('helvetica', 'bold');
+  pdf.text('DÉTAIL DES COÛTS:', margin, yPosition);
+  yPosition += 10;
+
+  // Ligne main d'œuvre
+  pdf.setFont('helvetica', 'normal');
+  pdf.text('Main d\'œuvre', margin, yPosition);
+  pdf.text(formatEuro(couts.coutMainOeuvre), pageWidth - margin - 40, yPosition, { align: 'right' });
+  yPosition += 8;
+
+  // Ligne matériaux
+  pdf.text('Matériaux et fournitures', margin, yPosition);
+  pdf.text(formatEuro(couts.coutMateriaux), pageWidth - margin - 40, yPosition, { align: 'right' });
+  yPosition += 8;
+
+  // Ligne sous-traitance
+  if (couts.coutSousTraitance > 0) {
+    pdf.text('Sous-traitance', margin, yPosition);
+    pdf.text(formatEuro(couts.coutSousTraitance), pageWidth - margin - 40, yPosition, { align: 'right' });
+    yPosition += 8;
+  }
+
+  // Ligne frais généraux
+  pdf.text(`Frais généraux (${chantier.fraisGeneraux}%)`, margin, yPosition);
+  pdf.text(formatEuro(couts.fraisGeneraux), pageWidth - margin - 40, yPosition, { align: 'right' });
+  yPosition += 8;
+
+  // Ligne sous-total HT
+  pdf.line(margin, yPosition, pageWidth - margin, yPosition);
+  yPosition += 5;
+  pdf.setFont('helvetica', 'bold');
+  pdf.text('SOUS-TOTAL HT', margin, yPosition);
+  pdf.text(formatEuro(couts.coutTotal), pageWidth - margin - 40, yPosition, { align: 'right' });
+  yPosition += 10;
+
+  // TVA (supposons 20% par défaut)
+  const tva = calculerTVA(couts.coutTotal, '20');
+  pdf.setFont('helvetica', 'normal');
+  pdf.text('TVA (20%)', margin, yPosition);
+  pdf.text(formatEuro(tva), pageWidth - margin - 40, yPosition, { align: 'right' });
+  yPosition += 8;
+
+  // Total TTC
+  pdf.line(margin, yPosition, pageWidth - margin, yPosition);
+  yPosition += 5;
+  pdf.setFontSize(14);
+  pdf.setFont('helvetica', 'bold');
+  pdf.text('TOTAL TTC', margin, yPosition);
+  pdf.text(formatEuro(couts.coutTotal + tva), pageWidth - margin - 40, yPosition, { align: 'right' });
+  yPosition += 20;
+
+  // Conditions
+  pdf.setFontSize(10);
+  pdf.setFont('helvetica', 'normal');
+  pdf.text('CONDITIONS:', margin, yPosition);
+  yPosition += 8;
+  pdf.text('- Devis valable 30 jours', margin, yPosition);
+  yPosition += 5;
+  pdf.text('- Acompte de 30% à la commande', margin, yPosition);
+  yPosition += 5;
+  pdf.text('- Solde à la livraison', margin, yPosition);
+  yPosition += 5;
+  pdf.text('- Garantie décennale incluse', margin, yPosition);
+
+  // Pied de page
+  const dateDevis = new Date().toLocaleDateString('fr-FR');
+  pdf.text(`Devis établi le ${dateDevis}`, margin, pdf.internal.pageSize.height - 20);
+
+  return pdf;
+};
+
+export const genererRecapitulatifChantier = (
+  chantier: Chantier,
+  salaries: Salarie[],
+  materiaux: Materiau[],
+  sousTraitants: SousTraitant[] = []
+) => {
+  const pdf = new jsPDF();
+  const pageWidth = pdf.internal.pageSize.width;
+  const margin = 20;
+  let yPosition = margin;
+
+  // Titre
+  pdf.setFontSize(18);
+  pdf.setFont('helvetica', 'bold');
+  pdf.text('RÉCAPITULATIF CHANTIER', pageWidth / 2, yPosition, { align: 'center' });
+  yPosition += 20;
+
+  // Informations chantier
+  pdf.setFontSize(12);
+  pdf.text(`Chantier: ${chantier.nom}`, margin, yPosition);
+  yPosition += 8;
+  pdf.text(`Référence: ${chantier.reference}`, margin, yPosition);
+  yPosition += 8;
+  pdf.text(`Adresse: ${chantier.adresse}`, margin, yPosition);
+  yPosition += 15;
+
+  // Détail main d'œuvre
+  pdf.setFont('helvetica', 'bold');
+  pdf.text('DÉTAIL MAIN D\'ŒUVRE:', margin, yPosition);
+  yPosition += 10;
+
+  chantier.salaries.forEach(cs => {
+    const salarie = salaries.find(s => s.id === cs.salarieId);
+    if (!salarie) return;
+
+    pdf.setFont('helvetica', 'normal');
+    pdf.text(`${salarie.prenom} ${salarie.nom}`, margin, yPosition);
+    yPosition += 6;
+
+    cs.presences.forEach(presence => {
+      const date = new Date(presence.date).toLocaleDateString('fr-FR');
+      const heures = `${presence.heuresPresence}h${presence.heuresSupplementaires ? ` +${presence.heuresSupplementaires}h supp.` : ''}`;
+      const cout = calculerCoutChantierSalarie(
+        salarie.tauxHoraire,
+        presence.heuresPresence,
+        presence.heuresSupplementaires || 0
+      );
+      
+      pdf.text(`  ${date}: ${heures} = ${formatEuro(cout)}`, margin + 10, yPosition);
+      if (presence.commentaire) {
+        pdf.setFont('helvetica', 'italic');
+        pdf.text(`    "${presence.commentaire}"`, margin + 15, yPosition + 4);
+        pdf.setFont('helvetica', 'normal');
+        yPosition += 4;
+      }
+      yPosition += 6;
+    });
+    
+    pdf.setFont('helvetica', 'bold');
+    pdf.text(`Total: ${formatEuro(cs.coutTotal)}`, margin + 10, yPosition);
+    yPosition += 10;
+  });
+
+  // Détail sous-traitance
+  if (chantier.sousTraitants && chantier.sousTraitants.length > 0) {
+    pdf.setFont('helvetica', 'bold');
+    pdf.text('DÉTAIL SOUS-TRAITANCE:', margin, yPosition);
+    yPosition += 10;
+
+    chantier.sousTraitants.forEach(cst => {
+      const sousTraitant = sousTraitants.find(st => st.id === cst.sousTraitantId);
+      if (!sousTraitant) return;
+
+      pdf.setFont('helvetica', 'normal');
+      pdf.text(`${sousTraitant.entreprise} - ${sousTraitant.nom}`, margin, yPosition);
+      yPosition += 6;
+      pdf.text(`  ${cst.description}`, margin + 10, yPosition);
+      yPosition += 6;
+      
+      pdf.setFont('helvetica', 'bold');
+      pdf.text(`Total: ${formatEuro(cst.coutTotal)}`, margin + 10, yPosition);
+      yPosition += 10;
+    });
+  }
+
+  // Calculs finaux
+  const couts = calculerCoutsChantier(chantier, salaries, materiaux, sousTraitants);
+  yPosition += 10;
+  
+  pdf.setFont('helvetica', 'bold');
+  pdf.text('RÉCAPITULATIF FINANCIER:', margin, yPosition);
+  yPosition += 10;
+  
+  pdf.setFont('helvetica', 'normal');
+  pdf.text(`Main d'œuvre: ${formatEuro(couts.coutMainOeuvre)}`, margin, yPosition);
+  yPosition += 6;
+  pdf.text(`Matériaux: ${formatEuro(couts.coutMateriaux)}`, margin, yPosition);
+  yPosition += 6;
+  if (couts.coutSousTraitance > 0) {
+    pdf.text(`Sous-traitance: ${formatEuro(couts.coutSousTraitance)}`, margin, yPosition);
+    yPosition += 6;
+  }
+  pdf.text(`Frais généraux: ${formatEuro(couts.fraisGeneraux)}`, margin, yPosition);
+  yPosition += 6;
+  
+  pdf.setFont('helvetica', 'bold');
+  pdf.text(`COÛT TOTAL: ${formatEuro(couts.coutTotal)}`, margin, yPosition);
+  
+  if (couts.margeReelle !== undefined) {
+    yPosition += 10;
+    pdf.text(`MARGE RÉALISÉE: ${couts.margeReelle.toFixed(1)}%`, margin, yPosition);
+  }
+
+  return pdf;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,65 @@
+export interface Salarie {
+  id: string;
+  nom: string;
+  prenom: string;
+  salaireNet: number;
+  salaireBrut: number;
+  chargesPatronales: number;
+  coutTotal: number;
+  tauxHoraire: number;
+  heuresParJour: number;
+}
+
+export interface Materiau {
+  id: string;
+  nom: string;
+  prixUnitaire: number;
+  unite: string;
+  quantite: number;
+  coutTotal: number;
+  fournisseur?: string;
+  categorie: string;
+}
+
+export interface ChantierSalarie {
+  salarieId: string;
+  presences: ChantierPresence[];
+  coutTotal: number;
+}
+
+export interface ChantierPresence {
+  date: string;
+  heuresPresence: number;
+  heuresSupplementaires?: number;
+  commentaire?: string;
+}
+
+export interface ChantierMateriau {
+  materiauId: string;
+  quantite: number;
+  coutTotal: number;
+}
+
+export interface Chantier {
+  id: string;
+  nom: string;
+  adresse: string;
+  dateDebut: string;
+  dateFin: string;
+  salaries: ChantierSalarie[];
+  materiaux: ChantierMateriau[];
+  fraisGeneraux: number;
+  prixVenteClient?: number;
+  coutMainOeuvre: number;
+  coutMateriaux: number;
+  coutTotal: number;
+  marge?: number;
+  status: 'en_cours' | 'termine' | 'planifie';
+}
+
+export interface CalculFiscal {
+  salaireNet: number;
+  salaireBrut: number;
+  chargesPatronales: number;
+  coutTotal: number;
+}

--- a/src/utils/calculsFiscaux.ts
+++ b/src/utils/calculsFiscaux.ts
@@ -1,0 +1,64 @@
+import { CalculFiscal } from '../types';
+
+// Taux de charges sociales BTP en France (2024)
+const TAUX_CHARGES_SALARIALES = 0.22; // 22%
+const TAUX_CHARGES_PATRONALES = 0.44; // 44% (spécifique BTP)
+
+export const calculerSalaireBrut = (salaireNet: number): number => {
+  return salaireNet / (1 - TAUX_CHARGES_SALARIALES);
+};
+
+export const calculerChargesPatronales = (salaireBrut: number): number => {
+  return salaireBrut * TAUX_CHARGES_PATRONALES;
+};
+
+export const calculerCoutTotal = (salaireBrut: number, chargesPatronales: number): number => {
+  return salaireBrut + chargesPatronales;
+};
+
+export const calculCompletSalaire = (salaireNet: number): CalculFiscal => {
+  const salaireBrut = calculerSalaireBrut(salaireNet);
+  const chargesPatronales = calculerChargesPatronales(salaireBrut);
+  const coutTotal = calculerCoutTotal(salaireBrut, chargesPatronales);
+
+  return {
+    salaireNet,
+    salaireBrut,
+    chargesPatronales,
+    coutTotal
+  };
+};
+
+export const calculerTauxHoraire = (coutTotal: number, heuresParMois: number = 151.67): number => {
+  return coutTotal / heuresParMois;
+};
+
+export const calculerCoutChantierSalarie = (
+  tauxHoraire: number,
+  totalHeures: number,
+  heuresSupplementaires: number = 0
+): number => {
+  // Heures normales + heures supplémentaires majorées à 25%
+  const coutHeuresNormales = tauxHoraire * (totalHeures - heuresSupplementaires);
+  const coutHeuresSupp = tauxHoraire * heuresSupplementaires * 1.25;
+  return coutHeuresNormales + coutHeuresSupp;
+};
+
+export const formatEuro = (montant: number): string => {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR'
+  }).format(montant);
+};
+
+export const formatPourcentage = (valeur: number): string => {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'percent',
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1
+  }).format(valeur);
+};
+
+export const calculerTVA = (montantHT: number, tauxTVA: string): number => {
+  return montantHT * (parseFloat(tauxTVA) / 100);
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- affiche un bandeau d’erreur discret dans l’onglet simulateur lorsque l’appel d’estimation échoue
- désactive le bouton « Estimer via API » tant que la requête est en cours et ignore les clics répétés
- réinitialise l’estimation sur changement de scénario d’exemple et affiche un résumé du résultat obtenu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6b56bf840832a9b91fd578b78fd13