### PR TITLE
Add API estimation endpoint contract documentation

### DIFF
--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,25 @@
+# Contrat API Estimation Chantier
+POST /api/estimation
+Content-Type: application/json
+
+Request:
+{
+  "postes": [
+    { "id": "uuid", "nom": "Maçonnerie", "charge": 24 } // charge en heures
+  ]
+}
+
+Response 200:
+{
+  "postes": [
+    { "id": "uuid", "coutMateriaux": 1320, "coutMainOeuvre": 840 }
+  ],
+  "totalHT": 2160,
+  "margeEstimee": 388
+}
+
+Notes:
+- L’API doit conserver les mêmes `id` pour le mapping.
+- Les coûts sont exprimés en EUR HT.
+- `margeEstimee` = marge globale prévisionnelle (libre côté serveur).
+- Tolérer `charge` = 0 (poste gratuit), refuser négatif.


### PR DESCRIPTION
## Summary
- add documentation for the estimation API contract detailing request and response payloads
- include notes about id preservation, currency, margin definition, and charge validation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6bd1b4680832a845d40d2e836fd86