### PR TITLE
Document estimation API setup and tighten typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Calculateur de coût de chantiers BTP
+
+Application Vite + React destinée à estimer et suivre les coûts d'un chantier BTP.
+
+## Installation rapide
+
+```bash
+npm install
+npm run dev
+```
+
+## Estimation API
+
+L'application lit sa configuration distante depuis `/public/config.json`. Ce fichier doit être présent dans le dossier `public` du projet (voir l'exemple ci-dessous) et sera servi en lecture seule via l'URL `/config.json`.
+
+```json
+{
+  "API_BASE_URL": "mock"
+}
+```
+
+- Lorsque `API_BASE_URL` vaut `mock` (ou que la clé est absente/`null`), l'API d'estimation fonctionne en mode maquette. Le service `estimerChantier` simule alors la latence réseau, calcule des montants factices pour chaque poste et renvoie un total hors taxes ainsi qu'une marge estimée.
+- En mode réel, l'application effectue un POST sur `${API_BASE_URL}/api/estimation` avec le payload suivant :
+
+```json
+{
+  "postes": [
+    { "id": "uuid", "nom": "Terrassement", "charge": 42 }
+  ]
+}
+```
+
+Chaque poste correspond à une tâche de chantier, identifiée par `id`, avec un libellé (`nom`) et une charge exprimée en heures (`charge`).
+
+Pour basculer en production, mettez à jour `public/config.json` en renseignant l'URL de base de l'API déployée :
+
+```json
+{
+  "API_BASE_URL": "https://mon-api.btp.example"
+}
+```
+
+Le front consommera alors l'endpoint `/api/estimation` exposé par ce domaine.

--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,3 @@
+{
+  "API_BASE_URL": "mock"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { SalarieSchema, MateriauSchema, ChantierSchema, SousTraitantSchema, Sala
 import { z } from 'zod';
 import { newId } from './lib/id';
 import { estimerChantier, type EstimationResponse, type PosteTravail } from '@/domain/api';
+import { formatEuro } from './utils/calculsFiscaux';
 
 function App() {
   const [activeTab, setActiveTab] = useState(() => {
@@ -201,7 +202,7 @@ function App() {
                     <p>
                       Estimation totale HT :
                       {' '}
-                      {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(estimation.totalHT)}
+                      {formatEuro(estimation.totalHT)}
                     </p>
                     <p>Marge estimée : {estimation.margeEstimee}%</p>
                     {estimation.postes.length > 0 && (
@@ -223,13 +224,13 @@ function App() {
                                 <tr key={poste.id} className="border-b border-emerald-100">
                                   <td className="border px-2 py-1">{label}</td>
                                   <td className="border px-2 py-1 text-right">
-                                    {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(poste.coutMateriaux)}
+                                    {formatEuro(poste.coutMateriaux)}
                                   </td>
                                   <td className="border px-2 py-1 text-right">
-                                    {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(poste.coutMainOeuvre)}
+                                    {formatEuro(poste.coutMainOeuvre)}
                                   </td>
                                   <td className="border px-2 py-1 text-right font-medium">
-                                    {new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(sousTotal)}
+                                    {formatEuro(sousTotal)}
                                   </td>
                                 </tr>
                               );

--- a/src/components/Chantiers/ChantierForm.tsx
+++ b/src/components/Chantiers/ChantierForm.tsx
@@ -17,6 +17,15 @@ interface ChantierFormProps {
   onCancel: () => void;
 }
 
+type TauxTVAOption = '5.5' | '10' | '20';
+
+interface NewMateriauState {
+  materiauId: string;
+  quantite: string;
+  prixUnitaireReel: string;
+  tauxTVA: TauxTVAOption;
+}
+
 export const ChantierForm: React.FC<ChantierFormProps> = ({
   chantier,
   salaries,
@@ -75,11 +84,11 @@ export const ChantierForm: React.FC<ChantierFormProps> = ({
   // États pour les formulaires d'ajout
   const [selectedSalarieId, setSelectedSalarieId] = useState('');
   const [selectedSousTraitantId, setSelectedSousTraitantId] = useState('');
-  const [newMateriau, setNewMateriau] = useState({
+  const [newMateriau, setNewMateriau] = useState<NewMateriauState>({
     materiauId: '',
     quantite: '',
     prixUnitaireReel: '',
-    tauxTVA: '20' as const
+    tauxTVA: '20'
   });
   const [newSousTraitant, setNewSousTraitant] = useState({
     sousTraitantId: '',
@@ -780,12 +789,17 @@ export const ChantierForm: React.FC<ChantierFormProps> = ({
                   step="0.01"
                   value={newMateriau.prixUnitaireReel}
                   onChange={(e) => setNewMateriau({ ...newMateriau, prixUnitaireReel: e.target.value })}
-                  placeholder="Prix réel (opt.)"
+                  placeholder="Prix réel (optionnel)"
                   className="px-3 py-2 border rounded-md focus:ring-2 focus:ring-orange-500"
                 />
                 <select
                   value={newMateriau.tauxTVA}
-                  onChange={(e) => setNewMateriau({ ...newMateriau, tauxTVA: e.target.value as any })}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (value === '5.5' || value === '10' || value === '20') {
+                      setNewMateriau({ ...newMateriau, tauxTVA: value });
+                    }
+                  }}
                   className="px-3 py-2 border rounded-md focus:ring-2 focus:ring-orange-500"
                 >
                   <option value="5.5">TVA 5,5%</option>

--- a/src/components/Chantiers/ChantiersManager.tsx
+++ b/src/components/Chantiers/ChantiersManager.tsx
@@ -175,7 +175,6 @@ export const ChantiersManager: React.FC<ChantiersManagerProps> = ({
           salaries={salaries}
           materiaux={materiaux}
           sousTraitants={sousTraitants}
-          sousTraitants={sousTraitants}
           onSave={editingChantier ? modifierChantier : ajouterChantier}
           onCancel={() => {
             setShowForm(false);

--- a/src/components/EstimerButton.tsx
+++ b/src/components/EstimerButton.tsx
@@ -1,11 +1,33 @@
 import { useState } from 'react';
 import { estimerChantier, type EstimationResponse, type PosteTravail } from '../domain/api';
-export default function EstimerButton({ postes, onDone, onError }:{ postes:PosteTravail[]; onDone:(r:EstimationResponse)=>void; onError:(m:string)=>void; }) {
+
+interface EstimerButtonProps {
+  postes: PosteTravail[];
+  onDone: (response: EstimationResponse) => void;
+  onError: (message: string) => void;
+}
+
+export default function EstimerButton({ postes, onDone, onError }: EstimerButtonProps) {
   const [loading, setLoading] = useState(false);
-  return <button disabled={loading} onClick={async()=>{
-    if (loading) return; setLoading(true);
-    try { const r=await estimerChantier({ postes }); onDone(r); }
-    catch(e:any){ onError(e?.message||'Erreur inconnue'); }
-    finally{ setLoading(false); }
-  }}>{loading?'Estimation…':'Estimer via API'}</button>;
+
+  const handleClick = async () => {
+    if (loading) return;
+    setLoading(true);
+
+    try {
+      const response = await estimerChantier({ postes });
+      onDone(response);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Erreur inconnue';
+      onError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button disabled={loading} onClick={handleClick}>
+      {loading ? 'Estimation…' : 'Estimer via API'}
+    </button>
+  );
 }

--- a/src/components/Salaries/SalarieForm.tsx
+++ b/src/components/Salaries/SalarieForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Save, X, User } from 'lucide-react';
 import { Salarie, SalarieFormData, SalarieFormSchema } from '../../schemas';
-import { calculCompletSalaire, calculerTauxHoraire } from '../../utils/calculsFiscaux';
+import { calculCompletSalaire, calculerTauxHoraire, formatEuro } from '../../utils/calculsFiscaux';
 
 interface SalarieFormProps {
   salarie?: Salarie | null;
@@ -191,20 +191,20 @@ export const SalarieForm: React.FC<SalarieFormProps> = ({ salarie, onSave, onCan
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm">
               <div>
                 <span className="text-gray-600 block">Salaire brut:</span>
-                <span className="font-semibold text-blue-600">{calculs.salaireBrut.toFixed(2)} €</span>
+                <span className="font-semibold text-blue-600">{formatEuro(calculs.salaireBrut)}</span>
               </div>
               <div>
                 <span className="text-gray-600 block">Charges patronales:</span>
-                <span className="font-semibold text-orange-600">{calculs.chargesPatronales.toFixed(2)} €</span>
+                <span className="font-semibold text-orange-600">{formatEuro(calculs.chargesPatronales)}</span>
               </div>
               <div>
                 <span className="text-gray-600 block">Coût total employeur:</span>
-                <span className="font-semibold text-green-600">{calculs.coutTotal.toFixed(2)} €</span>
+                <span className="font-semibold text-green-600">{formatEuro(calculs.coutTotal)}</span>
               </div>
               <div>
                 <span className="text-gray-600 block">Taux horaire:</span>
                 <span className="font-semibold text-purple-600">
-                  {calculerTauxHoraire(calculs.coutTotal).toFixed(2)} €/h
+                  {`${formatEuro(calculerTauxHoraire(calculs.coutTotal))}/h`}
                 </span>
               </div>
             </div>

--- a/src/components/Simulator/EstimationResultsCard.tsx
+++ b/src/components/Simulator/EstimationResultsCard.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { EstimationResponse, PosteTravail } from '../../domain/api';
+import { formatEuro } from '../../utils/calculsFiscaux';
 
 interface EstimationResultsCardProps {
   estimation: EstimationResponse | null;
   postes: PosteTravail[];
 }
-
-const formatCurrency = (amount: number) => {
-  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(amount);
-};
 
 const EstimationResultsCard: React.FC<EstimationResultsCardProps> = ({ estimation, postes }) => {
   if (!estimation) return null;
@@ -39,9 +36,9 @@ const EstimationResultsCard: React.FC<EstimationResultsCardProps> = ({ estimatio
               return (
                 <tr key={poste.id} className="border-b">
                   <td className="p-2 border">{posteNamesMap[poste.id] || `Poste ${poste.id}`}</td>
-                  <td className="p-2 border text-right">{formatCurrency(poste.coutMateriaux)}</td>
-                  <td className="p-2 border text-right">{formatCurrency(poste.coutMainOeuvre)}</td>
-                  <td className="p-2 border text-right font-medium">{formatCurrency(sousTotal)}</td>
+                  <td className="p-2 border text-right">{formatEuro(poste.coutMateriaux)}</td>
+                  <td className="p-2 border text-right">{formatEuro(poste.coutMainOeuvre)}</td>
+                  <td className="p-2 border text-right font-medium">{formatEuro(sousTotal)}</td>
                 </tr>
               );
             })}
@@ -49,7 +46,7 @@ const EstimationResultsCard: React.FC<EstimationResultsCardProps> = ({ estimatio
           <tfoot className="bg-gray-50">
             <tr>
               <td colSpan={3} className="p-2 border text-right font-semibold">Total HT</td>
-              <td className="p-2 border text-right font-semibold">{formatCurrency(estimation.totalHT)}</td>
+              <td className="p-2 border text-right font-semibold">{formatEuro(estimation.totalHT)}</td>
             </tr>
             <tr>
               <td colSpan={3} className="p-2 border text-right font-semibold">Marge estimée</td>

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -96,7 +96,7 @@ export function useLocalStorage<T>({
     };
   }, [key, data, version]);
 
-  const importData = useCallback((importedData: any) => {
+  const importData = useCallback((importedData: StorageData<unknown>) => {
     try {
       const validated = schema.parse(importedData.data);
       return saveData(validated);

--- a/src/services/importExportService.ts
+++ b/src/services/importExportService.ts
@@ -23,14 +23,20 @@ export const exportToJSON = (data: {
   URL.revokeObjectURL(url);
 };
 
-export const exportToCSV = (data: any[], filename: string, headers: string[]) => {
+export const exportToCSV = <T extends Record<string, unknown>>(
+  data: T[],
+  filename: string,
+  headers: (keyof T & string)[]
+) => {
   const csvContent = [
     headers.join(','),
     ...data.map(row => headers.map(header => {
-      const value = row[header] || '';
-      return typeof value === 'string' && value.includes(',') 
-        ? `"${value}"` 
-        : value;
+      const rawValue = row[header];
+      if (rawValue === undefined || rawValue === null) {
+        return '';
+      }
+      const stringValue = String(rawValue);
+      return stringValue.includes(',') ? `"${stringValue}"` : stringValue;
     }).join(','))
   ].join('\n');
   
@@ -43,12 +49,12 @@ export const exportToCSV = (data: any[], filename: string, headers: string[]) =>
   URL.revokeObjectURL(url);
 };
 
-export const importFromJSON = (file: File): Promise<any> => {
+export const importFromJSON = <T = unknown>(file: File): Promise<T> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = (e) => {
       try {
-        const data = JSON.parse(e.target?.result as string);
+        const data = JSON.parse(e.target?.result as string) as T;
         resolve(data);
       } catch (error) {
         reject(new Error('Fichier JSON invalide'));

--- a/src/services/localStorage.ts
+++ b/src/services/localStorage.ts
@@ -1,4 +1,5 @@
 import { Salarie, Materiau, Chantier } from '../types';
+import { formatEuro } from '../utils/calculsFiscaux';
 
 const STORAGE_KEYS = {
   SALARIES: 'btp-calculator-salaries',
@@ -63,17 +64,17 @@ ${detailsPresences.map(detail => `
 Salarié ID: ${detail.salarieId}
 - ${detail.nombreJours} jours travaillés
 - ${detail.totalHeures}h normales${detail.totalHeuresSupp > 0 ? ` + ${detail.totalHeuresSupp}h supplémentaires` : ''}
-- Coût: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(detail.coutTotal)}
+- Coût: ${formatEuro(detail.coutTotal)}
 
 Détail des présences:
 ${detail.presences.map(p => `  ${p.date}: ${p.heuresPresence}h${p.heuresSupplementaires ? ` +${p.heuresSupplementaires}h supp.` : ''}${p.commentaire ? ` (${p.commentaire})` : ''}`).join('\n')}
 `).join('\n')}
 
-Main d'œuvre: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(chantier.coutMainOeuvre)}
-Matériaux: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(chantier.coutMateriaux)}
-Frais généraux: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format((chantier.coutMainOeuvre + chantier.coutMateriaux) * (chantier.fraisGeneraux / 100))}
+Main d'œuvre: ${formatEuro(chantier.coutMainOeuvre)}
+Matériaux: ${formatEuro(chantier.coutMateriaux)}
+Frais généraux: ${formatEuro((chantier.coutMainOeuvre + chantier.coutMateriaux) * (chantier.fraisGeneraux / 100))}
 
-COÛT TOTAL: ${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(chantier.coutTotal)}
+COÛT TOTAL: ${formatEuro(chantier.coutTotal)}
 ${chantier.marge ? `MARGE: ${new Intl.NumberFormat('fr-FR', { style: 'percent', maximumFractionDigits: 1 }).format(chantier.marge / 100)}` : ''}
   `.trim();
 


### PR DESCRIPTION
## Summary
- document the estimation API configuration and usage in the README and add a default config.json
- replace remaining `any` usages with typed alternatives and tidy minor UI typos
- centralize euro formatting across estimation, salary and export flows for consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6bf36c5c0832ab888f31943c0a0c1