### PR TITLE
feat: enrichir l'estimation avec complexité et historique

### DIFF
--- a/src/components/PostesForm.tsx
+++ b/src/components/PostesForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { PosteTravail } from '../domain/api';
+import { POSTE_TYPE_DEFINITIONS, POSTE_TYPE_ORDER, computeChargePonderee, type PosteTravailType } from '@/domain/posteTypes';
 
 interface PostesFormProps {
   value: PosteTravail[];
@@ -7,9 +8,10 @@ interface PostesFormProps {
 }
 
 const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
-  const [newPoste, setNewPoste] = useState<{ nom: string; charge: string }>({
+  const [newPoste, setNewPoste] = useState<{ nom: string; charge: string; typePoste: PosteTravailType }>({
     nom: '',
-    charge: ''
+    charge: '',
+    typePoste: 'standard'
   });
   const [errors, setErrors] = useState<{ nom?: string; charge?: string }>({});
 
@@ -37,13 +39,14 @@ const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
       const newPosteItem: PosteTravail = {
         id: crypto.randomUUID(),
         nom: newPoste.nom.trim(),
-        charge: parseFloat(newPoste.charge)
+        charge: parseFloat(newPoste.charge),
+        typePoste: newPoste.typePoste
       };
-      
+
       onChange([...value, newPosteItem]);
-      
+
       // Réinitialiser le formulaire
-      setNewPoste({ nom: '', charge: '' });
+      setNewPoste({ nom: '', charge: '', typePoste: 'standard' });
       setErrors({});
     }
   };
@@ -52,7 +55,7 @@ const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
     onChange(value.filter(poste => poste.id !== id));
   };
 
-  const handleEditPoste = (id: string, field: 'nom' | 'charge', newValue: string) => {
+  const handleEditPoste = (id: string, field: 'nom' | 'charge' | 'typePoste', newValue: string) => {
     const updatedPostes = value.map(poste => {
       if (poste.id === id) {
         if (field === 'nom') {
@@ -62,11 +65,13 @@ const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
           if (!isNaN(chargeValue) && chargeValue >= 0) {
             return { ...poste, charge: chargeValue };
           }
+        } else if (field === 'typePoste') {
+          return { ...poste, typePoste: newValue as PosteTravailType };
         }
       }
       return poste;
     });
-    
+
     onChange(updatedPostes);
   };
 
@@ -78,7 +83,9 @@ const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
         <thead>
           <tr className="bg-gray-100">
             <th className="text-left p-2 border">Nom</th>
+            <th className="text-left p-2 border">Type</th>
             <th className="text-left p-2 border">Charge (h)</th>
+            <th className="text-left p-2 border">Charge pondérée (h)</th>
             <th className="text-left p-2 border">Actions</th>
           </tr>
         </thead>
@@ -94,6 +101,19 @@ const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
                 />
               </td>
               <td className="p-2 border">
+                <select
+                  value={poste.typePoste ?? 'standard'}
+                  onChange={(e) => handleEditPoste(poste.id, 'typePoste', e.target.value)}
+                  className="w-full p-1 border rounded"
+                >
+                  {POSTE_TYPE_ORDER.map((type) => (
+                    <option key={type} value={type}>
+                      {POSTE_TYPE_DEFINITIONS[type].label}
+                    </option>
+                  ))}
+                </select>
+              </td>
+              <td className="p-2 border">
                 <input
                   type="number"
                   min="0"
@@ -102,6 +122,9 @@ const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
                   onChange={(e) => handleEditPoste(poste.id, 'charge', e.target.value)}
                   className="w-full p-1 border rounded"
                 />
+              </td>
+              <td className="p-2 border text-right">
+                {computeChargePonderee(poste.charge, poste.typePoste).toFixed(2)}
               </td>
               <td className="p-2 border">
                 <button
@@ -127,6 +150,19 @@ const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
               {errors.nom && <p className="text-red-500 text-xs mt-1">{errors.nom}</p>}
             </td>
             <td className="p-2 border">
+              <select
+                value={newPoste.typePoste}
+                onChange={(e) => setNewPoste({ ...newPoste, typePoste: e.target.value as PosteTravailType })}
+                className="w-full p-1 border rounded"
+              >
+                {POSTE_TYPE_ORDER.map((type) => (
+                  <option key={type} value={type}>
+                    {POSTE_TYPE_DEFINITIONS[type].label}
+                  </option>
+                ))}
+              </select>
+            </td>
+            <td className="p-2 border">
               <input
                 type="number"
                 min="0"
@@ -137,6 +173,11 @@ const PostesForm: React.FC<PostesFormProps> = ({ value, onChange }) => {
                 className={`w-full p-1 border rounded ${errors.charge ? 'border-red-500' : ''}`}
               />
               {errors.charge && <p className="text-red-500 text-xs mt-1">{errors.charge}</p>}
+            </td>
+            <td className="p-2 border text-right text-gray-500">
+              {newPoste.charge
+                ? computeChargePonderee(parseFloat(newPoste.charge) || 0, newPoste.typePoste).toFixed(2)
+                : '0.00'}
             </td>
             <td className="p-2 border">
               <button

--- a/src/components/Simulator/EstimationResultsCard.tsx
+++ b/src/components/Simulator/EstimationResultsCard.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { EstimationResponse, PosteTravail } from '../../domain/api';
 import { formatEuro } from '../../utils/calculsFiscaux';
+import { computeChargePonderee } from '@/domain/posteTypes';
 
 interface EstimationResultsCardProps {
   estimation: EstimationResponse | null;
   postes: PosteTravail[];
+  targetMargin: number;
 }
 
-const EstimationResultsCard: React.FC<EstimationResultsCardProps> = ({ estimation, postes }) => {
+const EstimationResultsCard: React.FC<EstimationResultsCardProps> = ({ estimation, postes, targetMargin }) => {
   if (!estimation) return null;
 
   // Créer un mapping des IDs de postes vers les noms
@@ -16,10 +18,16 @@ const EstimationResultsCard: React.FC<EstimationResultsCardProps> = ({ estimatio
     return acc;
   }, {} as Record<string, string>);
 
+  const margeRealisableMontant = estimation.margeEstimee;
+  const margeRealisablePourcentage = estimation.totalHT === 0
+    ? 0
+    : (margeRealisableMontant / estimation.totalHT) * 100;
+  const ecart = margeRealisablePourcentage - targetMargin;
+
   return (
     <div className="mt-6 p-4 bg-white rounded-lg shadow">
       <h3 className="text-lg font-semibold mb-4">Résultat API</h3>
-      
+
       <div className="overflow-x-auto">
         <table className="w-full border-collapse">
           <thead>
@@ -28,17 +36,20 @@ const EstimationResultsCard: React.FC<EstimationResultsCardProps> = ({ estimatio
               <th className="text-right p-2 border">Coût Matériaux</th>
               <th className="text-right p-2 border">Coût Main d'Œuvre</th>
               <th className="text-right p-2 border">Sous-total</th>
+              <th className="text-right p-2 border">Charge pondérée (h)</th>
             </tr>
           </thead>
           <tbody>
             {estimation.postes.map(poste => {
               const sousTotal = poste.coutMateriaux + poste.coutMainOeuvre;
+              const posteInitial = postes.find((p) => p.id === poste.id);
               return (
                 <tr key={poste.id} className="border-b">
                   <td className="p-2 border">{posteNamesMap[poste.id] || `Poste ${poste.id}`}</td>
                   <td className="p-2 border text-right">{formatEuro(poste.coutMateriaux)}</td>
                   <td className="p-2 border text-right">{formatEuro(poste.coutMainOeuvre)}</td>
                   <td className="p-2 border text-right font-medium">{formatEuro(sousTotal)}</td>
+                  <td className="p-2 border text-right">{posteInitial ? computeChargePonderee(posteInitial.charge, posteInitial.typePoste).toFixed(2) : '-'}</td>
                 </tr>
               );
             })}
@@ -49,11 +60,32 @@ const EstimationResultsCard: React.FC<EstimationResultsCardProps> = ({ estimatio
               <td className="p-2 border text-right font-semibold">{formatEuro(estimation.totalHT)}</td>
             </tr>
             <tr>
-              <td colSpan={3} className="p-2 border text-right font-semibold">Marge estimée</td>
-              <td className="p-2 border text-right font-semibold">{estimation.margeEstimee}%</td>
+              <td colSpan={3} className="p-2 border text-right font-semibold">Marge réalisable</td>
+              <td className="p-2 border text-right font-semibold">
+                {formatEuro(margeRealisableMontant)}
+                <span className="ml-2 text-sm font-normal text-gray-600">
+                  ({margeRealisablePourcentage.toFixed(1)}%)
+                </span>
+              </td>
+              <td className="p-2 border" />
             </tr>
           </tfoot>
         </table>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3 text-sm">
+        <div className="rounded border border-blue-100 bg-blue-50 p-3">
+          <p className="text-xs uppercase text-blue-600">Marge cible</p>
+          <p className="text-lg font-semibold">{targetMargin.toFixed(1)}%</p>
+        </div>
+        <div className="rounded border border-emerald-100 bg-emerald-50 p-3">
+          <p className="text-xs uppercase text-emerald-600">Marge réalisable</p>
+          <p className="text-lg font-semibold">{margeRealisablePourcentage.toFixed(1)}%</p>
+        </div>
+        <div className={`rounded p-3 border ${ecart >= 0 ? 'border-emerald-100 bg-emerald-50 text-emerald-700' : 'border-amber-100 bg-amber-50 text-amber-700'}`}>
+          <p className="text-xs uppercase">Écart</p>
+          <p className="text-lg font-semibold">{ecart >= 0 ? '+' : ''}{ecart.toFixed(1)}%</p>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Simulator/Simulator.tsx
+++ b/src/components/Simulator/Simulator.tsx
@@ -3,6 +3,7 @@ import { Salarie, Materiau, Chantier } from '../../types';
 import PostesForm from '../PostesForm';
 import EstimationResultsCard from './EstimationResultsCard';
 import { PosteTravail, EstimationResponse, estimerChantier } from '../../domain/api';
+import { useEstimationHistory } from '../../hooks/useEstimationHistory';
 
 interface SimulatorProps {
   salaries: Salarie[];
@@ -15,6 +16,8 @@ export const Simulator: React.FC<SimulatorProps> = ({ salaries, materiaux, chant
   const [estimation, setEstimation] = useState<EstimationResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [targetMargin, setTargetMargin] = useState<number>(20);
+  const estimationHistory = useEstimationHistory();
 
   const handleCalculer = async () => {
     if (postes.length === 0) {
@@ -28,6 +31,12 @@ export const Simulator: React.FC<SimulatorProps> = ({ salaries, materiaux, chant
     try {
       const result = await estimerChantier({ postes });
       setEstimation(result);
+      const postesSnapshot = postes.map((poste) => ({ ...poste }));
+      estimationHistory.addEntry({
+        postes: postesSnapshot,
+        estimation: result,
+        targetMargin,
+      });
     } catch (err) {
       setError(`Erreur lors de l'estimation: ${err instanceof Error ? err.message : 'Erreur inconnue'}`);
       console.error(err);
@@ -40,9 +49,24 @@ export const Simulator: React.FC<SimulatorProps> = ({ salaries, materiaux, chant
     <div className="space-y-6">
       <div className="bg-white p-6 rounded-lg shadow">
         <h2 className="text-xl font-bold mb-4">Simulateur de coûts</h2>
-        
+
         <div className="mb-6">
           <PostesForm value={postes} onChange={setPostes} />
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Marge cible (%)</label>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              step={0.5}
+              value={targetMargin}
+              onChange={(event) => setTargetMargin(Number(event.target.value))}
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </div>
         </div>
 
         <div className="mt-4">
@@ -62,7 +86,7 @@ export const Simulator: React.FC<SimulatorProps> = ({ salaries, materiaux, chant
         </div>
 
         {/* Carte de résultats API */}
-        <EstimationResultsCard estimation={estimation} postes={postes} />
+        <EstimationResultsCard estimation={estimation} postes={postes} targetMargin={targetMargin} />
       </div>
     </div>
   );

--- a/src/domain/api.ts
+++ b/src/domain/api.ts
@@ -1,23 +1,55 @@
 import { getConfig } from '@/lib/config';
+import { computeChargePonderee, getPosteTypeCoefficient, type PosteTravailType } from './posteTypes';
 
-export type PosteTravail = { id: string; nom: string; charge: number }; // charge en heures
+export type PosteTravail = {
+  id: string;
+  nom: string;
+  charge: number; // charge initiale saisie
+  typePoste?: PosteTravailType;
+};
+
 export type EstimationRequest = { postes: PosteTravail[] };
 export type EstimationPoste = { id: string; coutMateriaux: number; coutMainOeuvre: number };
 export type EstimationResponse = { postes: EstimationPoste[]; totalHT: number; margeEstimee: number };
 
+type PosteTravailPayload = {
+  id: string;
+  nom: string;
+  charge: number;
+  typePoste: PosteTravailType;
+  chargeInitiale: number;
+  coefficientTypePoste: number;
+};
+
 export async function estimerChantier(data: EstimationRequest): Promise<EstimationResponse> {
   const { apiBaseUrl } = await getConfig();
-  
+
+  const postesPayload: PosteTravailPayload[] = data.postes.map((poste) => {
+    const typePoste = poste.typePoste ?? 'standard';
+    const chargeInitiale = poste.charge;
+    const chargePonderee = computeChargePonderee(chargeInitiale, typePoste);
+    const coefficientTypePoste = getPosteTypeCoefficient(typePoste);
+
+    return {
+      id: poste.id,
+      nom: poste.nom,
+      typePoste,
+      charge: chargePonderee,
+      chargeInitiale,
+      coefficientTypePoste,
+    };
+  });
+
   // Mode mock si apiBaseUrl est null ou 'mock'
   if (apiBaseUrl === null || apiBaseUrl === 'mock') {
     // Simuler un délai réseau
     await new Promise(r => setTimeout(r, 400));
-    
+
     // Générer les données mock
-    const postes: EstimationPoste[] = data.postes.map(poste => {
+    const postes: EstimationPoste[] = postesPayload.map(poste => {
       const coutMateriaux = Math.round(poste.charge * 55);
       const coutMainOeuvre = Math.round(poste.charge * 35);
-      
+
       return {
         id: poste.id,
         coutMateriaux,
@@ -26,7 +58,7 @@ export async function estimerChantier(data: EstimationRequest): Promise<Estimati
     });
     
     // Calculer le total HT
-    const totalHT = postes.reduce((sum, poste) => 
+    const totalHT = postes.reduce((sum, poste) =>
       sum + poste.coutMateriaux + poste.coutMainOeuvre, 0);
     
     // Calculer la marge estimée
@@ -44,7 +76,7 @@ export async function estimerChantier(data: EstimationRequest): Promise<Estimati
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
+    body: JSON.stringify({ postes: postesPayload }),
   });
   if (!res.ok) throw new Error(`API estimation ${res.status}`);
   return res.json();

--- a/src/domain/posteTypes.ts
+++ b/src/domain/posteTypes.ts
@@ -1,0 +1,43 @@
+export const POSTE_TYPE_ORDER = ['leger', 'standard', 'complexe', 'expert'] as const;
+export type PosteTravailType = typeof POSTE_TYPE_ORDER[number];
+
+export type PosteTypeDefinition = {
+  label: string;
+  coefficient: number;
+  description: string;
+};
+
+export const POSTE_TYPE_DEFINITIONS: Record<PosteTravailType, PosteTypeDefinition> = {
+  leger: {
+    label: 'Faible complexité',
+    coefficient: 0.85,
+    description: 'Tâches simples avec peu de risques et une technicité limitée.'
+  },
+  standard: {
+    label: 'Standard',
+    coefficient: 1,
+    description: 'Postes courants sans difficulté particulière.'
+  },
+  complexe: {
+    label: 'Complexe',
+    coefficient: 1.25,
+    description: 'Travaux nécessitant une coordination accrue ou des compétences spécifiques.'
+  },
+  expert: {
+    label: 'Expert',
+    coefficient: 1.5,
+    description: 'Interventions hautement techniques avec un niveau d’expertise élevé.'
+  }
+};
+
+export function getPosteTypeCoefficient(type: PosteTravailType | undefined): number {
+  if (!type) {
+    return POSTE_TYPE_DEFINITIONS.standard.coefficient;
+  }
+  return POSTE_TYPE_DEFINITIONS[type]?.coefficient ?? POSTE_TYPE_DEFINITIONS.standard.coefficient;
+}
+
+export function computeChargePonderee(charge: number, type: PosteTravailType | undefined): number {
+  const coefficient = getPosteTypeCoefficient(type);
+  return Math.round(charge * coefficient * 100) / 100;
+}

--- a/src/hooks/useEstimationHistory.ts
+++ b/src/hooks/useEstimationHistory.ts
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+import { useLocalStorage } from './useLocalStorage';
+import { EstimationHistorySchema, type EstimationHistoryItem } from '@/schemas';
+import { z } from 'zod';
+
+const HISTORY_KEY = 'btp-estimation-history';
+const HISTORY_VERSION = 1;
+
+const EstimationHistoryArraySchema = EstimationHistorySchema;
+
+type EstimationHistoryInput = Omit<EstimationHistoryItem, 'id' | 'createdAt'> & {
+  id?: string;
+  createdAt?: number;
+};
+
+export function useEstimationHistory() {
+  const storage = useLocalStorage<z.infer<typeof EstimationHistoryArraySchema>>({
+    key: HISTORY_KEY,
+    schema: EstimationHistoryArraySchema,
+    defaultValue: [],
+    version: HISTORY_VERSION,
+  });
+
+  const { data, setData, ...rest } = storage;
+
+  const addEntry = useCallback((entry: EstimationHistoryInput) => {
+    const newEntry: EstimationHistoryItem = {
+      id: entry.id ?? crypto.randomUUID(),
+      createdAt: entry.createdAt ?? Date.now(),
+      postes: entry.postes.map((poste) => ({ ...poste })),
+      estimation: entry.estimation,
+      targetMargin: entry.targetMargin,
+    };
+
+    const nextHistory = [...data, newEntry];
+    // Garder uniquement les 20 dernières estimations pour éviter l'inflation du stockage
+    const trimmedHistory = nextHistory.slice(-20);
+    setData(trimmedHistory);
+  }, [data, setData]);
+
+  return {
+    data,
+    setData,
+    ...rest,
+    addEntry,
+  };
+}
+
+export type { EstimationHistoryItem } from '@/schemas';

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,6 +1,26 @@
 import { z } from 'zod';
+import { POSTE_TYPE_ORDER } from '@/domain/posteTypes';
 
 // Schémas de base
+export const PosteTravailSchema = z.object({
+  id: z.string(),
+  nom: z.string(),
+  charge: z.number().min(0),
+  typePoste: z.enum(POSTE_TYPE_ORDER).optional(),
+});
+
+export const EstimationPosteSchema = z.object({
+  id: z.string(),
+  coutMateriaux: z.number().min(0),
+  coutMainOeuvre: z.number().min(0),
+});
+
+export const EstimationResponseSchema = z.object({
+  postes: z.array(EstimationPosteSchema),
+  totalHT: z.number().min(0),
+  margeEstimee: z.number(),
+});
+
 export const SalarieSchema = z.object({
   id: z.string(),
   nom: z.string().min(1, 'Le nom est requis'),
@@ -154,8 +174,8 @@ export const SalarieFormSchema = SalarieSchema.omit({
 
 export const MateriauFormSchema = MateriauSchema.omit({ id: true });
 
-export const ChantierFormSchema = ChantierSchema.omit({ 
-  id: true, 
+export const ChantierFormSchema = ChantierSchema.omit({
+  id: true,
   dateCreation: true,
   coutMainOeuvre: true,
   coutMateriaux: true,
@@ -169,3 +189,15 @@ export type SousTraitantFormData = z.infer<typeof SousTraitantFormSchema>;
 export type SalarieFormData = z.infer<typeof SalarieFormSchema>;
 export type MateriauFormData = z.infer<typeof MateriauFormSchema>;
 export type ChantierFormData = z.infer<typeof ChantierFormSchema>;
+
+export const EstimationHistoryItemSchema = z.object({
+  id: z.string(),
+  createdAt: z.number(),
+  postes: z.array(PosteTravailSchema),
+  estimation: EstimationResponseSchema,
+  targetMargin: z.number().min(0).max(100),
+});
+
+export const EstimationHistorySchema = z.array(EstimationHistoryItemSchema);
+
+export type EstimationHistoryItem = z.infer<typeof EstimationHistoryItemSchema>;


### PR DESCRIPTION
## Summary
- introduire les types de postes avec pondération automatique des charges envoyées à l'API
- ajouter la saisie d'une marge cible et afficher l'écart avec la marge réalisable dans les résultats
- enregistrer chaque estimation avec sa marge cible dans le localStorage pour constituer un historique

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c24d313c832a82089d1c249bcbe4