### PR TITLE
Fix GitHub Pages base path and config fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,15 @@ Pour basculer en production, mettez à jour `public/config.json` en renseignant 
 ```
 
 Le front consommera alors l'endpoint `/api/estimation` exposé par ce domaine.
+
+## Déploiement sur GitHub Pages
+
+Une configuration automatique est prévue pour GitHub Pages : lors d'un build exécuté
+dans un workflow GitHub Actions, la variable d'environnement `GITHUB_REPOSITORY`
+est utilisée pour déduire le sous-répertoire de publication (par exemple
+`/mon-repo/`). Le bundle généré fonctionnera ainsi à la fois en local et sur
+`https://<utilisateur>.github.io/<mon-repo>/` sans réglage manuel du `base` Vite.
+
+Veillez également à conserver le fichier `public/config.json` dans le dossier
+`dist` publié afin que l'application puisse charger sa configuration via
+`import.meta.env.BASE_URL`.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,7 +6,9 @@ export async function getConfig(): Promise<AppConfig> {
   if (cache) return cache;
   
   try {
-    const res = await fetch('/config.json', { cache: 'no-store' });
+    const res = await fetch(`${import.meta.env.BASE_URL}config.json`, {
+      cache: 'no-store',
+    });
     if (!res.ok) return (cache = { apiBaseUrl: null });
     
     const json = await res.json();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,10 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 
 // https://vitejs.dev/config/
+const repoName = process.env.GITHUB_REPOSITORY?.split('/')?.[1];
+
 export default defineConfig({
+  base: repoName ? `/${repoName}/` : '/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- detect the GitHub Pages repository name to configure Vite's base path automatically
- load the remote configuration via import.meta.env.BASE_URL so assets resolve correctly on Pages
- document the GitHub Pages deployment behaviour in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c39f3a98832a85aec96c7e7c49c4