### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Calculateur de Coûts Chantier BTP</title>
   </head>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,12 @@ import path from 'path';
 
 // https://vitejs.dev/config/
 const repoName = process.env.GITHUB_REPOSITORY?.split('/')?.[1];
+const isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
 
-export default defineConfig({
-  base: repoName ? `/${repoName}/` : '/',
+export default defineConfig(({ command }) => ({
+  base: command === 'build'
+    ? (repoName && isGitHubActions ? `/${repoName}/` : './')
+    : '/',
   plugins: [react()],
   resolve: {
     alias: {
@@ -16,4 +19,4 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
-});
+}));


### PR DESCRIPTION
## Summary
- ensure the Vite build falls back to relative asset URLs when not running inside GitHub Actions
- adjust the favicon link to use a relative path so it resolves correctly on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c7ac3bb4832a9ae1d81dd43da10a