### PR TITLE
Estimate labour costs from production quantities

### DIFF
--- a/src/components/Simulator/Simulator.tsx
+++ b/src/components/Simulator/Simulator.tsx
@@ -49,8 +49,8 @@ const createEmptyLine = <K extends LotCollectionKey>(key: K, params: ParamsGloba
       return {
         poste: '',
         mode: 'h_par_unite',
-        productivite: 1,
-        quantiteRef: 1,
+        productivite: 0,
+        quantiteRef: 0,
         tauxHoraireHt: params.tauxHoraireMoDefaut,
         chargesPct: params.chargesSocialesDefautPct,
       } as CollectionMap[K][number];
@@ -93,9 +93,9 @@ const cloneLibraryValue = <K extends LibraryCategory>(value: LibraryEntries[K][n
  main
 const libraryEntries: LibraryEntries = {
   mo: [
-    { label: 'Maçon', value: { poste: 'Maçon', mode: 'h_par_unite', productivite: 1, quantiteRef: 1, tauxHoraireHt: 42, chargesPct: 45 } },
-    { label: 'Manœuvre', value: { poste: 'Manœuvre', mode: 'h_par_unite', productivite: 1, quantiteRef: 1, tauxHoraireHt: 32, chargesPct: 45 } },
-    { label: "Chef d'équipe", value: { poste: "Chef d'équipe", mode: 'h_par_unite', productivite: 1, quantiteRef: 1, tauxHoraireHt: 48, chargesPct: 45 } },
+    { label: 'Maçon', value: { poste: 'Maçon', mode: 'h_par_unite', productivite: 0, quantiteRef: 0, tauxHoraireHt: 42, chargesPct: 45 } },
+    { label: 'Manœuvre', value: { poste: 'Manœuvre', mode: 'h_par_unite', productivite: 0, quantiteRef: 0, tauxHoraireHt: 32, chargesPct: 45 } },
+    { label: "Chef d'équipe", value: { poste: "Chef d'équipe", mode: 'h_par_unite', productivite: 0, quantiteRef: 0, tauxHoraireHt: 48, chargesPct: 45 } },
   ],
   engins: [
     { label: 'Pelle 1,7T', value: { type: 'Pelle 1,7T', tauxJourHt: 240, jours: 1, carburantPct: 6, maintenancePct: 4 } },
@@ -148,8 +148,22 @@ const collectionColumns: Record<LotCollectionKey, TableColumn[]> = {
         { label: 'Unités / heure', value: 'unites_par_h' },
       ],
     },
-    { key: 'productivite', header: 'Productivité', inputType: 'number', min: 0, step: 0.01, ariaLabel: 'Productivité' },
-    { key: 'quantiteRef', header: 'Quantité réf.', inputType: 'number', min: 0, step: 0.01, ariaLabel: 'Quantité de référence' },
+    {
+      key: 'productivite',
+      header: 'Ajustement manuel (h/unité)',
+      inputType: 'number',
+      min: 0,
+      step: 0.05,
+      ariaLabel: 'Ajustement manuel de productivité en heures par unité',
+    },
+    {
+      key: 'quantiteRef',
+      header: 'Quantité (m² / unité)',
+      inputType: 'number',
+      min: 0,
+      step: 0.01,
+      ariaLabel: 'Quantité totale en unités ou m²',
+    },
     { key: 'tauxHoraireHt', header: 'Taux horaire HT', inputType: 'number', min: 0, step: 0.5, ariaLabel: 'Taux horaire hors taxe' },
     { key: 'chargesPct', header: 'Charges %', inputType: 'number', min: 0, max: 100, step: 0.5, ariaLabel: 'Charges sociales en pourcentage' },
   ],
@@ -898,6 +912,13 @@ export const Simulator: React.FC = () => {
                             </tbody>
                           </table>
                         </div>
+                        {key === 'mo' && (
+                          <p className="mt-2 text-xs text-gray-500">
+                            Les coûts de main d’œuvre sont désormais estimés automatiquement à partir des quantités saisies
+                            (m², ml ou unités). Le champ «&nbsp;Ajustement manuel&nbsp;» permet de corriger ponctuellement
+                            le temps estimé (en heures par unité) si nécessaire.
+                          </p>
+                        )}
                       </div>
                     ))}
                   </div>

--- a/src/core/calc.ts
+++ b/src/core/calc.ts
@@ -79,19 +79,102 @@ const computeMateriau = (ligne: LigneMateriau): number => {
   return quantite * pu;
 };
 
-const computeMainOeuvre = (ligne: LigneMO): number => {
-  const tauxHoraire = Number.isFinite(ligne.tauxHoraireHt) ? Math.max(ligne.tauxHoraireHt, 0) : 0;
-  const charges = Number.isFinite(ligne.chargesPct) ? Math.max(ligne.chargesPct, 0) : 0;
-  const productivite = Number.isFinite(ligne.productivite) ? Math.max(ligne.productivite, 0) : 0;
-  const quantiteRef = Number.isFinite(ligne.quantiteRef) ? Math.max(ligne.quantiteRef, 0) : 0;
+const normalizeText = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase();
 
+interface ProductivityProfile {
+  keywords: string[];
+  heuresParUnite: number;
+}
+
+const DEFAULT_HEURES_PAR_UNITE = 0.35; // ~21 minutes par unité/m² par défaut
+
+const PRODUCTIVITY_PROFILES: ProductivityProfile[] = [
+  { keywords: ['macon', 'maçon', 'gros oeuvre', 'gros-oeuvre'], heuresParUnite: 0.4 },
+  { keywords: ['manoeuvre', 'manœuvre'], heuresParUnite: 0.32 },
+  { keywords: ['chef', 'conducteur'], heuresParUnite: 0.22 },
+  { keywords: ['terrass', 'terrassement'], heuresParUnite: 0.38 },
+  { keywords: ['coffr', 'beton'], heuresParUnite: 0.45 },
+  { keywords: ['charpent', 'ossature'], heuresParUnite: 0.5 },
+  { keywords: ['couvreur', 'toiture'], heuresParUnite: 0.42 },
+  { keywords: ['plaqu', 'placo', 'platre', 'plâtr'], heuresParUnite: 0.28 },
+  { keywords: ['isolation'], heuresParUnite: 0.25 },
+  { keywords: ['menuiserie'], heuresParUnite: 0.4 },
+  { keywords: ['peint', 'finitions'], heuresParUnite: 0.22 },
+  { keywords: ['carrel'], heuresParUnite: 0.33 },
+  { keywords: ['electric'], heuresParUnite: 0.6 },
+  { keywords: ['plomb', 'sanitaire'], heuresParUnite: 0.55 },
+  { keywords: ['hvac', 'clim', 'ventil'], heuresParUnite: 0.58 },
+];
+
+const findProfile = (poste: string): ProductivityProfile | undefined => {
+  if (!poste) {
+    return undefined;
+  }
+  const normalized = normalizeText(poste);
+  return PRODUCTIVITY_PROFILES.find((profile) =>
+    profile.keywords.some((keyword) => normalized.includes(keyword)),
+  );
+};
+
+const scaleFactorFromQuantite = (quantite: number): number => {
+  if (quantite <= 0) {
+    return 0;
+  }
+  if (quantite < 20) {
+    return 1.15;
+  }
+  if (quantite < 100) {
+    return 1;
+  }
+  if (quantite < 300) {
+    return 0.95;
+  }
+  if (quantite < 600) {
+    return 0.9;
+  }
+  return 0.85;
+};
+
+const extractUserHeuresParUnite = (ligne: LigneMO): number => {
+  const productivite = Number.isFinite(ligne.productivite) ? Math.max(ligne.productivite, 0) : 0;
   if (productivite === 0) {
     return 0;
   }
+  if (ligne.mode === 'h_par_unite') {
+    return productivite;
+  }
+  return productivite > 0 ? 1 / productivite : 0;
+};
 
-  const heures = ligne.mode === 'h_par_unite'
-    ? quantiteRef * productivite
-    : quantiteRef / productivite;
+const estimateHeuresFromQuantite = (ligne: LigneMO): number => {
+  const quantiteRef = Number.isFinite(ligne.quantiteRef) ? Math.max(ligne.quantiteRef, 0) : 0;
+  if (quantiteRef === 0) {
+    return 0;
+  }
+
+  const profile = findProfile(ligne.poste);
+  const baseHeuresParUnite = profile?.heuresParUnite ?? DEFAULT_HEURES_PAR_UNITE;
+  const userHeuresParUnite = extractUserHeuresParUnite(ligne);
+  const heuresParUnite = userHeuresParUnite > 0
+    ? baseHeuresParUnite * 0.7 + userHeuresParUnite * 0.3
+    : baseHeuresParUnite;
+
+  const scaleFactor = scaleFactorFromQuantite(quantiteRef);
+  return quantiteRef * heuresParUnite * scaleFactor;
+};
+
+const computeMainOeuvre = (ligne: LigneMO): number => {
+  const tauxHoraire = Number.isFinite(ligne.tauxHoraireHt) ? Math.max(ligne.tauxHoraireHt, 0) : 0;
+  const charges = Number.isFinite(ligne.chargesPct) ? Math.max(ligne.chargesPct, 0) : 0;
+
+  const heures = estimateHeuresFromQuantite(ligne);
+  if (heures === 0) {
+    return 0;
+  }
 
   const coutHoraireCharge = tauxHoraire * (1 + charges * PERCENT);
   return heures * coutHoraireCharge;
@@ -131,12 +214,13 @@ const computeCategories = (lot: Lot): {
     categorie: 'mo',
     designation: ligne.poste,
     quantite: Number.isFinite(ligne.quantiteRef) ? ligne.quantiteRef : null,
-    unite: ligne.mode === 'h_par_unite' ? 'unité' : 'h',
+    unite: 'unité',
     params: {
       mode: ligne.mode,
       productivite: ligne.productivite,
       tauxHoraireHt: ligne.tauxHoraireHt,
       chargesPct: ligne.chargesPct,
+      heuresEstimees: Math.round((estimateHeuresFromQuantite(ligne) + Number.EPSILON) * 100) / 100,
     },
     coutLigne: computeMainOeuvre(ligne),
   }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -156,7 +156,7 @@ export const DEFAULT_DATA: Projet = {
         { designation: 'Acier HA Fe500', unite: 'kg', quantite: 850, puHt: 1.65 },
       ],
       mo: [
-        { poste: 'Maçon qualifié', mode: 'h_par_unite', productivite: 0.35, quantiteRef: 1200, tauxHoraireHt: 42, chargesPct: 45 },
+        { poste: 'Maçon qualifié', mode: 'h_par_unite', productivite: 0, quantiteRef: 1200, tauxHoraireHt: 42, chargesPct: 45 },
       ],
       engins: [
         { type: 'Pelle 5T', tauxJourHt: 320, jours: 3, carburantPct: 8, maintenancePct: 4 },


### PR DESCRIPTION
## Summary
- derive main d'œuvre costs from quantities using a catalogue of productivity profiles instead of raw hours
- expose the automatically computed hour estimate on each labour line and update simulator inputs to focus on unit quantities
- refresh defaults and guidance so newly added labour tasks rely on automatic estimation by default

## Testing
- npm run build *(fails: existing HTML parsing error in index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68d95b7c0e4c832aa48b002d5b81b648